### PR TITLE
Core `EncryptedLogging` code from FluxC

### DIFF
--- a/encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/LogEncrypterTest.kt
+++ b/encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/LogEncrypterTest.kt
@@ -1,0 +1,169 @@
+package com.automattic.encryptedlogging
+
+import android.util.Base64
+import android.util.Base64.DEFAULT
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.KeyPair
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLoggingKey
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedSecretStreamKey
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptionUtils
+import com.automattic.encryptedlogging.model.encryptedlogging.LogEncrypter
+import com.automattic.encryptedlogging.model.encryptedlogging.SecretStreamKey
+import java.util.UUID
+import kotlin.random.Random.Default.nextInt
+
+class LogEncrypterTest {
+    private lateinit var keypair: KeyPair
+    private val logDecrypter: LogDecrypter = LogDecrypter()
+
+    @Before
+    fun setup() {
+        keypair = EncryptionUtils.sodium.cryptoBoxKeypair()
+    }
+
+    @Test
+    @Throws
+    fun testThatEncryptedLogsMatchV1FileFormat() {
+        val testLogString = UUID.randomUUID().toString()
+        val encryptedLog = encryptContent(testLogString)
+
+        val json = JSONObject(encryptedLog)
+        assertEquals(
+                "`keyedWith` must ALWAYS be v1 in this version of the file format",
+                "v1",
+                json.getString("keyedWith")
+        )
+
+        assertNotNull(
+                "The UUID must be valid",
+                UUID.fromString(json.getString("uuid"))
+        )
+
+        assertEquals(
+                "The header must be 32 bytes long",
+                32,
+                json.getString("header").count()
+        )
+
+        assertEquals(
+                "The encrypted key should be 108 bytes long",
+                108,
+                json.getString("encryptedKey").count()
+        )
+
+        assertEquals(
+                "There should be one message and the closing tag",
+                2,
+                json.getJSONArray("messages").length()
+        )
+    }
+
+    @Test
+    fun testThatLogsCanBeDecrypted() {
+        val testLogString = UUID.randomUUID().toString()
+        assertEquals(testLogString, decryptContent(encryptContent(testLogString)))
+    }
+
+    @Test
+    fun testThatMultilineLogsCanBeDecrypted() {
+        val testLogString = (0..(nextInt(100) + 2)).joinToString(separator = "\n") { UUID.randomUUID().toString() }
+        assertEquals(testLogString, decryptContent(encryptContent(testLogString)))
+    }
+
+    @Test
+    fun testThatEmptyLogsCanBeEncrypted() {
+        val testLogString = ""
+        assertEquals(testLogString, decryptContent(encryptContent(testLogString)))
+    }
+
+    @Test
+    fun testThatExplicitUUIDsCanBeRetrievedFromEncryptedLogs() {
+        val testUuid = UUID.randomUUID().toString()
+
+        val (_, uuid) = logDecrypter.decrypt(encryptContent("", testUuid), keypair)
+        assertEquals(uuid, testUuid)
+    }
+
+    // Helpers
+
+    private fun encryptContent(content: String, uuid: String = UUID.randomUUID().toString()): String {
+        return LogEncrypter(EncryptedLoggingKey(keypair.publicKey)).encrypt(content, uuid)
+    }
+
+    private fun decryptContent(encryptedText: String): String {
+        return logDecrypter.decrypt(encryptedText, keypair).first
+    }
+}
+
+/**
+ * EncryptedStream represents the encrypted stream once the key has been decrypted. It exists to separate
+ * the key decryption from the stream decryption while decoding.
+ *
+ * @param key An unencrypted SecretStreamKey used to decrypt the remainder of the log.
+ * @param header A `ByteArray` representing the stream header – it's used to initialize the decryption stream.
+ * @param messages A `List<ByteArray>` of encrypted messages
+ */
+private class EncryptedStream(val key: SecretStreamKey, val header: ByteArray, val messages: List<ByteArray>)
+
+private const val JSON_KEYED_WITH_KEY = "keyedWith"
+private const val JSON_UUID_KEY = "uuid"
+private const val JSON_HEADER_KEY = "header"
+private const val JSON_ENCRYPTED_KEY_KEY = "encryptedKey"
+private const val JSON_MESSAGES_KEY = "messages"
+
+/**
+ * LogDecrypter allows decrypting encrypted content.
+ */
+private class LogDecrypter {
+    private val sodium = EncryptionUtils.sodium
+    private val state = SecretStream.State.ByReference()
+
+    private fun encryptedStream(encryptedText: String, keyPair: KeyPair): Pair<EncryptedStream, String> {
+        val json = JSONObject(encryptedText)
+
+        require(json.getString(JSON_KEYED_WITH_KEY) == "v1") {
+            "This class can only parse files keyedWith the v1 implementation"
+        }
+
+        val uuid = json.getString(JSON_UUID_KEY)
+        val header = json.getString(JSON_HEADER_KEY).base64Decode()
+        val encryptedKey = EncryptedSecretStreamKey(json.getString(JSON_ENCRYPTED_KEY_KEY).base64Decode())
+        val messagesJson = json.getJSONArray(JSON_MESSAGES_KEY)
+
+        val messages = (0 until messagesJson.length()).map { messagesJson.getString(it).base64Decode() }
+
+        val encryptedStream = EncryptedStream(encryptedKey.decrypt(keyPair), header, messages)
+        check(sodium.cryptoSecretStreamInitPull(state, encryptedStream.header, encryptedStream.key.bytes))
+        return Pair(encryptedStream, uuid)
+    }
+
+    /**
+     * Decrypts and returns the log file as a String.
+     *
+     * @param encryptedText The encrypted text to decrypt.
+     * @param keyPair The public and secret key pair associated with this file. Both are required to decrypt the file.
+     */
+    fun decrypt(encryptedText: String, keyPair: KeyPair): Pair<String, String> {
+        val (encryptedStream, uuid) = encryptedStream(encryptedText, keyPair)
+        val decryptedText = encryptedStream.messages.fold("") { accumulated: String, cipherBytes: ByteArray ->
+            String
+            val plainBytes = ByteArray(cipherBytes.size - SecretStream.ABYTES)
+
+            val tag = ByteArray(1) // Stores the extracted tag. This implementation doesn't do anything with it.
+            check(sodium.cryptoSecretStreamPull(state, plainBytes, tag, cipherBytes, cipherBytes.size.toLong()))
+
+            accumulated + String(plainBytes)
+        }
+        return Pair(decryptedText, uuid)
+    }
+}
+
+// On Android base64 has lots of options, so define an extension to make it easier to avoid decoding issues.
+private fun String.base64Decode(): ByteArray {
+    return Base64.decode(this, DEFAULT)
+}

--- a/encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/release/ReleaseStack_EncryptedLogTest.kt
+++ b/encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/release/ReleaseStack_EncryptedLogTest.kt
@@ -1,0 +1,119 @@
+package com.automattic.encryptedlogging.release
+
+import org.greenrobot.eventbus.Subscribe
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.hasItem
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Ignore
+import org.junit.Test
+import com.automattic.encryptedlogging.TestUtils
+import com.automattic.encryptedlogging.generated.EncryptedLogActionBuilder
+import com.automattic.encryptedlogging.release.ReleaseStack_EncryptedLogTest.TestEvents.ENCRYPTED_LOG_UPLOADED_SUCCESSFULLY
+import com.automattic.encryptedlogging.release.ReleaseStack_EncryptedLogTest.TestEvents.ENCRYPTED_LOG_UPLOAD_FAILED_WITH_INVALID_UUID
+import com.automattic.encryptedlogging.store.EncryptedLogStore
+import com.automattic.encryptedlogging.store.EncryptedLogStore.OnEncryptedLogUploaded
+import com.automattic.encryptedlogging.store.EncryptedLogStore.OnEncryptedLogUploaded.EncryptedLogFailedToUpload
+import com.automattic.encryptedlogging.store.EncryptedLogStore.OnEncryptedLogUploaded.EncryptedLogUploadedSuccessfully
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.InvalidRequest
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.TooManyRequests
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogPayload
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+private const val NUMBER_OF_LOGS_TO_UPLOAD = 2
+private const val TEST_UUID_PREFIX = "TEST-UUID-"
+private const val INVALID_UUID = "INVALID_UUID" // Underscore is not allowed
+
+class ReleaseStack_EncryptedLogTest : ReleaseStack_Base() {
+    @Inject lateinit var encryptedLogStore: EncryptedLogStore
+
+    private var nextEvent: TestEvents? = null
+
+    private enum class TestEvents {
+        NONE,
+        ENCRYPTED_LOG_UPLOADED_SUCCESSFULLY,
+        ENCRYPTED_LOG_UPLOAD_FAILED_WITH_INVALID_UUID
+    }
+
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        mReleaseStackAppComponent.inject(this)
+        init()
+        nextEvent = TestEvents.NONE
+    }
+
+    @Test
+    @Ignore("Disabling as a part of effort to exclude flaky or failing tests." +
+        "See https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2665")
+    fun testQueueForUpload() {
+        nextEvent = ENCRYPTED_LOG_UPLOADED_SUCCESSFULLY
+
+        val testIds = testIds()
+        mCountDownLatch = CountDownLatch(testIds.size)
+        testIds.forEach { uuid ->
+            val payload = UploadEncryptedLogPayload(
+                    uuid = uuid,
+                    file = createTempFileWithContent(suffix = uuid, content = "Testing FluxC log upload for $uuid"),
+                    shouldStartUploadImmediately = true
+            )
+            mDispatcher.dispatch(EncryptedLogActionBuilder.newUploadLogAction(payload))
+        }
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    @Ignore("While 'testQueueForUpload' passes, this test fails and thus temporarily ignored")
+    fun testQueueForUploadForInvalidUuid() {
+        nextEvent = ENCRYPTED_LOG_UPLOAD_FAILED_WITH_INVALID_UUID
+
+        mCountDownLatch = CountDownLatch(1)
+        val payload = UploadEncryptedLogPayload(
+                uuid = INVALID_UUID,
+                file = createTempFile(suffix = INVALID_UUID),
+                shouldStartUploadImmediately = true
+        )
+        mDispatcher.dispatch(EncryptedLogActionBuilder.newUploadLogAction(payload))
+        assertTrue(mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS))
+    }
+
+    @Suppress("unused")
+    @Subscribe
+    fun onEncryptedLogUploaded(event: OnEncryptedLogUploaded) {
+        when (event) {
+            is EncryptedLogUploadedSuccessfully -> {
+                assertThat(nextEvent, `is`(ENCRYPTED_LOG_UPLOADED_SUCCESSFULLY))
+                assertThat(testIds(), hasItem(event.uuid))
+            }
+            is EncryptedLogFailedToUpload -> {
+                when (event.error) {
+                    is TooManyRequests -> {
+                        // If we are hitting too many requests, we just ignore the test as restarting it will not help
+                        assertThat(event.willRetry, `is`(true))
+                    }
+                    is InvalidRequest -> {
+                        assertThat(nextEvent, `is`(ENCRYPTED_LOG_UPLOAD_FAILED_WITH_INVALID_UUID))
+                        assertThat(event.willRetry, `is`(false))
+                    }
+                    else -> {
+                        throw AssertionError("Unexpected error occurred in onEncryptedLogUploaded: ${event.error}")
+                    }
+                }
+            }
+        }
+        mCountDownLatch.countDown()
+    }
+
+    private fun testIds() = (1..NUMBER_OF_LOGS_TO_UPLOAD).map { i ->
+        "$TEST_UUID_PREFIX$i"
+    }
+
+    private fun createTempFileWithContent(suffix: String, content: String): File {
+        val file = createTempFile(suffix = suffix)
+        file.writeText(content)
+        return file
+    }
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/action/EncryptedLogAction.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/action/EncryptedLogAction.kt
@@ -1,0 +1,14 @@
+package com.automattic.encryptedlogging.action
+
+import com.automattic.encryptedlogging.annotations.Action
+import com.automattic.encryptedlogging.annotations.ActionEnum
+import com.automattic.encryptedlogging.annotations.action.IAction
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogPayload
+
+@ActionEnum
+enum class EncryptedLogAction : IAction {
+    @Action(payloadType = UploadEncryptedLogPayload::class)
+    UPLOAD_LOG,
+    @Action
+    RESET_UPLOAD_STATES
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptedLog.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptedLog.kt
@@ -1,0 +1,78 @@
+package com.automattic.encryptedlogging.model.encryptedlogging
+
+import com.yarolegovich.wellsql.core.Identifiable
+import com.yarolegovich.wellsql.core.annotation.Column
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey
+import com.yarolegovich.wellsql.core.annotation.RawConstraints
+import com.yarolegovich.wellsql.core.annotation.Table
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.QUEUED
+import org.wordpress.android.util.DateTimeUtils
+import java.io.File
+import java.util.Date
+
+/**
+ * [EncryptedLog] and [EncryptedLogModel] are tied to each other, any change in one should be reflected in the other.
+ * [EncryptedLog] should be used within the app, [EncryptedLogModel] should be used for DB interactions.
+ */
+data class EncryptedLog(
+    val uuid: String,
+    val file: File,
+    val dateCreated: Date = Date(),
+    val uploadState: EncryptedLogUploadState = QUEUED,
+    val failedCount: Int = 0
+) {
+    companion object {
+        fun fromEncryptedLogModel(encryptedLogModel: EncryptedLogModel) =
+                EncryptedLog(
+                        dateCreated = DateTimeUtils.dateUTCFromIso8601(encryptedLogModel.dateCreated),
+                        // Crash if values are missing which shouldn't happen if there are no logic errors
+                        uuid = encryptedLogModel.uuid!!,
+                        file = File(encryptedLogModel.filePath),
+                        uploadState = encryptedLogModel.uploadState,
+                        failedCount = encryptedLogModel.failedCount
+                )
+    }
+}
+
+@Table
+@RawConstraints("UNIQUE(UUID) ON CONFLICT REPLACE")
+class EncryptedLogModel(@PrimaryKey @Column private var id: Int = 0) : Identifiable {
+    @Column var uuid: String? = null
+    @Column var filePath: String? = null
+    @Column var dateCreated: String? = null // ISO 8601-formatted date in UTC, e.g. 1955-11-05T14:15:00Z
+    @Column var uploadStateDbValue: Int = QUEUED.value
+    @Column var failedCount: Int = 0
+
+    override fun getId(): Int = id
+
+    override fun setId(id: Int) {
+        this.id = id
+    }
+
+    val uploadState: EncryptedLogUploadState
+        get() =
+            requireNotNull(
+                    EncryptedLogUploadState.values()
+                            .firstOrNull { it.value == uploadStateDbValue }) {
+                "The stateDbValue of the EncryptedLogUploadState didn't match any of the `EncryptedLogUploadState`s. " +
+                        "This likely happened because the EncryptedLogUploadState values " +
+                        "were altered without a DB migration."
+            }
+
+    companion object {
+        fun fromEncryptedLog(encryptedLog: EncryptedLog) = EncryptedLogModel()
+                .also {
+            it.uuid = encryptedLog.uuid
+            it.filePath = encryptedLog.file.path
+            it.dateCreated = DateTimeUtils.iso8601UTCFromDate(encryptedLog.dateCreated)
+            it.uploadStateDbValue = encryptedLog.uploadState.value
+            it.failedCount = encryptedLog.failedCount
+        }
+    }
+}
+
+enum class EncryptedLogUploadState(val value: Int) {
+    QUEUED(1),
+    UPLOADING(2),
+    FAILED(3)
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptedSecretStreamKey.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptedSecretStreamKey.kt
@@ -1,0 +1,54 @@
+package com.automattic.encryptedlogging.model.encryptedlogging
+
+import com.goterl.lazysodium.interfaces.Box
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.KeyPair
+
+/**
+ * A class representing an Encrypted Secret Stream Key.
+ *
+ * It can be decrypted to provide an SecretStreamKey, which is used to
+ * decrypted the messages within an Encrypted Log File
+ *
+ * @see SecretStreamKey
+ */
+class EncryptedSecretStreamKey(val bytes: ByteArray) {
+    companion object {
+        /**
+         * The expected size (in bytes) of an Encrypted Secret Stream Key.
+         */
+        const val size: Int = SecretStream.KEYBYTES + Box.SEALBYTES
+    }
+
+    init {
+        require(bytes.size == size) {
+            "An Encrypted Secret Stream Key must be exactly $size bytes"
+        }
+    }
+
+    /**
+     * Decrypt the key using the assocaited KeyPair (the `publicKey` originally used to encrypt it, and its
+     * corresponding `secretKey`).
+     */
+    fun decrypt(keyPair: KeyPair): SecretStreamKey {
+        val sodium = EncryptionUtils.sodium
+
+        val publicKeyBytes = keyPair.publicKey.asBytes
+        val secretKeyBytes = keyPair.secretKey.asBytes
+
+        require(Box.Checker.checkPublicKey(publicKeyBytes.size)) {
+            "The public key size is incorrect (should be ${Box.PUBLICKEYBYTES} bytes)"
+        }
+
+        require(Box.Checker.checkSecretKey(secretKeyBytes.size)) {
+            "The secret key size is incorrect (should be ${Box.SECRETKEYBYTES} bytes)"
+        }
+
+        val decryptedBytes = ByteArray(SecretStream.KEYBYTES) // Stores the decrypted bytes
+        check(sodium.cryptoBoxSealOpen(decryptedBytes, bytes, bytes.size.toLong(), publicKeyBytes, secretKeyBytes)) {
+            "The message key couldn't be decrypted – it's likely the wrong key pair is being used for decryption"
+        }
+
+        return SecretStreamKey(decryptedBytes)
+    }
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptionUtils.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptionUtils.kt
@@ -1,0 +1,17 @@
+package com.automattic.encryptedlogging.model.encryptedlogging
+
+import com.goterl.lazysodium.LazySodiumAndroid
+import com.goterl.lazysodium.SodiumAndroid
+
+/**
+ * Convenience helpers for Encrypted Logging
+ */
+object EncryptionUtils {
+    /**
+     * Use a single shared instance of the Sodium library.
+     *
+     * The initialization is inexpensive, but verbose, so this is just syntactic sugar.
+     */
+    @JvmStatic
+    val sodium = LazySodiumAndroid(SodiumAndroid())
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
@@ -1,0 +1,128 @@
+package com.automattic.encryptedlogging.model.encryptedlogging
+
+import android.util.Base64
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.interfaces.SecretStream.State
+import com.goterl.lazysodium.utils.Key
+import dagger.Reusable
+import javax.inject.Inject
+
+private const val ENCODED_ENCRYPTED_KEY_LENGTH = 108
+private const val ENCODED_HEADER_LENGTH = 32
+
+data class EncryptedLoggingKey(val publicKey: Key)
+
+/**
+ * [LogEncrypter] encrypts the logs for the given text.
+ **
+ * @param encryptedLoggingKey The public key used to encrypt the log
+ *
+ */
+@Reusable
+class LogEncrypter @Inject constructor(private val encryptedLoggingKey: EncryptedLoggingKey) {
+    /**
+     * Encrypts the given [text]. It also adds the given [uuid] to its headers.
+     *
+     * @param text Text contents to be encrypted
+     * @param uuid Uuid for the encrypted log
+     */
+    fun encrypt(text: String, uuid: String): String = buildString {
+        val state = State.ByReference()
+        append(buildHeader(uuid, state))
+        val lines = text.lines()
+        lines.asSequence().mapIndexed { index, line ->
+            if (index + 1 >= lines.size) {
+                // If it's the last element
+                line
+            } else {
+                "$line\n"
+            }
+        }.forEach { line ->
+            append(buildMessage(line, state))
+        }
+        append(buildFooter(state))
+    }
+
+    /**
+     * Encrypt and write the provided string to the encrypted log file.
+     * @param string: The string to be written to the file.
+     */
+    private fun buildMessage(string: String, state: State): String {
+        val encryptedString = encryptMessage(string, SecretStream.TAG_MESSAGE, state)
+        return "\t\t\"$encryptedString\",\n"
+    }
+
+    /**
+     * An internal convenience function to extract the header building process.
+     */
+    private fun buildHeader(uuid: String, state: State): String {
+        val header = ByteArray(SecretStream.HEADERBYTES)
+        val key = SecretStreamKey.generate().let {
+            check(EncryptionUtils.sodium.cryptoSecretStreamInitPush(state, header, it.bytes))
+            it.encrypt(encryptedLoggingKey.publicKey)
+        }
+
+        require(SecretStream.Checker.headerCheck(header.size)) {
+            "The secret stream header must be the correct length"
+        }
+
+        val encodedEncryptedKey = base64Encode(key.bytes)
+        check(encodedEncryptedKey.length == ENCODED_ENCRYPTED_KEY_LENGTH) {
+            "The encoded, encrypted key must always be $ENCODED_ENCRYPTED_KEY_LENGTH bytes long"
+        }
+
+        val encodedHeader = base64Encode(header)
+        check(encodedHeader.length == ENCODED_HEADER_LENGTH) {
+            "The encoded header must always be $ENCODED_HEADER_LENGTH bytes long"
+        }
+
+        return buildString {
+            append("{")
+            append("\t\"keyedWith\": \"v1\",\n")
+            append("\t\"encryptedKey\": \"$encodedEncryptedKey\",\n")
+            append("\t\"header\": \"$encodedHeader\",\n")
+            append("\t\"uuid\": \"$uuid\",\n")
+            append("\t\"messages\": [\n")
+        }
+    }
+
+    /**
+     * Add the closing file tag
+     */
+    private fun buildFooter(state: State): String {
+        val encryptedClosingTag = encryptMessage("", SecretStream.TAG_FINAL, state)
+        return buildString {
+            append("\t\t\"$encryptedClosingTag\"\n")
+            append("\t]\n")
+            append("}")
+        }
+    }
+
+    /**
+     * An internal convenience function to push more data into the sodium secret stream.
+     */
+    private fun encryptMessage(string: String, tag: Byte, state: State): String {
+        val plainBytes = string.toByteArray()
+
+        val encryptedBytes = ByteArray(SecretStream.ABYTES + plainBytes.size) // Stores the encrypted bytes
+        check(
+                EncryptionUtils.sodium.cryptoSecretStreamPush(
+                        state,
+                        encryptedBytes,
+                        plainBytes,
+                        plainBytes.size.toLong(),
+                        tag
+                )
+        ) {
+            "Unable to encrypt message: $string"
+        }
+
+        return base64Encode(encryptedBytes)
+    }
+}
+
+// On Android base64 has lots of options, so define a helper to make it easier to
+// avoid encoding issues.
+private fun base64Encode(byteArray: ByteArray): String {
+    return Base64.encodeToString(byteArray, Base64.NO_WRAP)
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/SecretStreamKey.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/SecretStreamKey.kt
@@ -1,0 +1,47 @@
+package com.automattic.encryptedlogging.model.encryptedlogging
+
+import com.goterl.lazysodium.interfaces.Box
+import com.goterl.lazysodium.interfaces.SecretStream
+import com.goterl.lazysodium.utils.Key
+
+/**
+ * A class representing an unencrypted Secret Stream Key.
+ *
+ * It can be encrypted to provide an EncryptedSecretStreamKey, which is used to secure
+ * an Encrypted Log file.
+ *
+ * @see EncryptedSecretStreamKey
+ */
+class SecretStreamKey(val bytes: ByteArray) {
+    companion object {
+        /**
+         * Generate a new (and securely random) secret stream key
+         */
+        fun generate(): SecretStreamKey {
+            return SecretStreamKey(EncryptionUtils.sodium.cryptoSecretStreamKeygen().asBytes)
+        }
+    }
+
+    init {
+        require(bytes.size == SecretStream.KEYBYTES) {
+            "A Secret Stream Key must be exactly ${SecretStream.KEYBYTES} bytes"
+        }
+    }
+
+    val size: Long = bytes.size.toLong()
+
+    fun encrypt(publicKey: Key): EncryptedSecretStreamKey {
+        val sodium = EncryptionUtils.sodium
+
+        require(Box.Checker.checkPublicKey(publicKey.asBytes.size)) {
+            "The public key must be the right length"
+        }
+
+        val encryptedBytes = ByteArray(EncryptedSecretStreamKey.size) // Stores the encrypted bytes
+        check(sodium.cryptoBoxSeal(encryptedBytes, bytes, size, publicKey.asBytes)) {
+            "Encrypting the message key must not fail"
+        }
+
+        return EncryptedSecretStreamKey(encryptedBytes)
+    }
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/network/BaseRequest.java
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/network/BaseRequest.java
@@ -1,0 +1,407 @@
+package com.automattic.encryptedlogging.network;
+
+import android.net.Uri;
+import android.net.Uri.Builder;
+import android.util.Base64;
+
+import androidx.annotation.NonNull;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.Cache;
+import com.android.volley.DefaultRetryPolicy;
+import com.android.volley.NetworkError;
+import com.android.volley.NetworkResponse;
+import com.android.volley.NoConnectionError;
+import com.android.volley.ParseError;
+import com.android.volley.Request;
+import com.android.volley.TimeoutError;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.HttpHeaderParser;
+
+import com.automattic.encryptedlogging.FluxCError;
+import com.automattic.encryptedlogging.network.xmlrpc.XMLRPCRequest;
+import com.automattic.encryptedlogging.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType;
+import com.automattic.encryptedlogging.store.AccountStore.AuthenticateErrorPayload;
+import com.automattic.encryptedlogging.utils.ErrorUtils.OnUnexpectedError;
+import org.wordpress.android.util.AppLog;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import static com.automattic.encryptedlogging.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.METHOD_NOT_ALLOWED;
+import static com.automattic.encryptedlogging.network.xmlrpc.XMLRPCRequest.XmlRpcErrorType.NOT_SET;
+
+public abstract class BaseRequest<T> extends Request<T> {
+    public static final int DEFAULT_REQUEST_TIMEOUT = 30000;
+    public static final int DEFAULT_MAX_RETRIES = DefaultRetryPolicy.DEFAULT_MAX_RETRIES;
+    public static final int UPLOAD_REQUEST_READ_TIMEOUT = 60000;
+
+    // Only used when enabledCaching is called - caching is off by default for all requests
+    public static final int DEFAULT_CACHE_LIFETIME = 10 * 60 * 1000;
+
+    public Uri mUri;
+
+    public interface OnAuthFailedListener {
+        void onAuthFailed(AuthenticateErrorPayload errorType);
+    }
+
+    public interface BaseErrorListener {
+        void onErrorResponse(@NonNull BaseNetworkError error);
+    }
+
+    public interface OnParseErrorListener {
+        void onParseError(OnUnexpectedError event);
+    }
+
+    private static final String USER_AGENT_HEADER = "User-Agent";
+
+    protected OnAuthFailedListener mOnAuthFailedListener;
+    protected OnParseErrorListener mOnParseErrorListener;
+    protected final Map<String, String> mHeaders = new HashMap<>(2);
+    private BaseErrorListener mErrorListener;
+
+    private boolean mResetCache;
+    private int mCacheTtl;
+    private int mCacheSoftTtl;
+
+    public static class BaseNetworkError implements FluxCError {
+        public GenericErrorType type;
+        public String message;
+        public VolleyError volleyError;
+        public XmlRpcErrorType xmlRpcErrorType = NOT_SET;
+
+        public BaseNetworkError(@NonNull BaseNetworkError error) {
+            this.message = error.message;
+            this.type = error.type;
+            this.volleyError = error.volleyError;
+        }
+
+        public BaseNetworkError(@NonNull GenericErrorType error, @NonNull String message,
+                                @NonNull VolleyError volleyError) {
+            this.message = message;
+            this.type = error;
+            this.volleyError = volleyError;
+        }
+
+        public BaseNetworkError(@NonNull GenericErrorType error, @NonNull VolleyError volleyError) {
+            this.message = "";
+            this.type = error;
+            this.volleyError = volleyError;
+        }
+
+        public BaseNetworkError(@NonNull GenericErrorType error,
+                                @NonNull VolleyError volleyError,
+                                @NonNull XmlRpcErrorType xmlRpcErrorType) {
+            this.message = "";
+            this.type = error;
+            this.volleyError = volleyError;
+            this.xmlRpcErrorType = xmlRpcErrorType;
+        }
+
+        public BaseNetworkError(@NonNull VolleyError volleyError) {
+            this.type = GenericErrorType.UNKNOWN;
+            this.message = "";
+            this.volleyError = volleyError;
+        }
+
+        public BaseNetworkError(@NonNull VolleyError volleyError, @NonNull XmlRpcErrorType xmlRpcErrorType) {
+            this.type = GenericErrorType.UNKNOWN;
+            this.message = "";
+            this.volleyError = volleyError;
+            this.xmlRpcErrorType = xmlRpcErrorType;
+        }
+
+        public BaseNetworkError(@NonNull GenericErrorType error) {
+            this.type = error;
+        }
+
+        public BaseNetworkError(@NonNull GenericErrorType error, @NonNull String message) {
+            this.type = error;
+            this.message = message;
+        }
+
+        public BaseNetworkError(@NonNull GenericErrorType error, @NonNull XmlRpcErrorType xmlRpcErrorType) {
+            this.type = error;
+            this.xmlRpcErrorType = xmlRpcErrorType;
+        }
+
+        public boolean isGeneric() {
+            return type != null;
+        }
+
+        public boolean hasVolleyError() {
+            return volleyError != null;
+        }
+
+        public String getCombinedErrorMessage() {
+            if (volleyError == null) {
+                return message != null ? message : "";
+            }
+            String volleyErrorMessage = volleyError.getMessage();
+            if (volleyErrorMessage == null || volleyErrorMessage.isEmpty()) {
+                return message != null ? message : "";
+            } else {
+                if (message == null || message.isEmpty()) {
+                    return volleyErrorMessage;
+                } else {
+                    return message + " • " + volleyErrorMessage;
+                }
+            }
+        }
+    }
+
+    public enum GenericErrorType {
+        // Network Layer
+        TIMEOUT,
+        NO_CONNECTION,
+        NETWORK_ERROR,
+
+        // HTTP Layer
+        NOT_FOUND,
+        CENSORED,
+        SERVER_ERROR,
+        INVALID_SSL_CERTIFICATE,
+        HTTP_AUTH_ERROR,
+
+        // Web Application Layer
+        INVALID_RESPONSE,
+        AUTHORIZATION_REQUIRED,
+        NOT_AUTHENTICATED,
+        PARSE_ERROR,
+
+        // Other
+        UNKNOWN,
+    }
+
+    public BaseRequest(int method, @NonNull String url, BaseErrorListener errorListener) {
+        super(method, url, null);
+        if (url != null) {
+            mUri = Uri.parse(url);
+        } else {
+            mUri = Uri.EMPTY;
+        }
+        mErrorListener = errorListener;
+        // Make sure all our custom Requests are never cached.
+        setShouldCache(false);
+        setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT,
+                DefaultRetryPolicy.DEFAULT_MAX_RETRIES, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
+    }
+
+    @Override
+    public String getUrl() {
+        return mUri.toString();
+    }
+
+    public void addQueryParameter(String key, String value) {
+        mUri = mUri.buildUpon().appendQueryParameter(key, value).build();
+    }
+
+    public void addQueryParameters(Map<String, String> parameters) {
+        if (parameters == null) {
+            return;
+        }
+        Builder builder = mUri.buildUpon();
+        for (String key : parameters.keySet()) {
+            builder.appendQueryParameter(key, parameters.get(key));
+        }
+        mUri = builder.build();
+    }
+
+    /**
+     * Enable caching for this request. The {@code timeToLive} param corresponds to the
+     * {@code ttl} field in {@link Cache}.
+     * <p>
+     * Disables soft expiry, which is when the cached result is returned, but a network request is also dispatched
+     * to update the cache.
+     *
+     * @param timeToLive the amount of time before the cache expires
+     */
+    public void enableCaching(int timeToLive) {
+        enableCaching(timeToLive, timeToLive);
+    }
+
+    /**
+     * Enable caching for this request. The {@code timeToLive} and {@code softTimeToLive} params correspond to the
+     * {@code ttl} and {@code softTtl} fields in {@link Cache}.
+     *
+     * @param timeToLive     the amount of time before the cache expires
+     * @param softTimeToLive the amount of time before the cache soft expires (the cached result is returned,
+     *                       but a network request is also dispatched to update the cache)
+     */
+    public void enableCaching(int timeToLive, int softTimeToLive) {
+        setShouldCache(true);
+        mCacheTtl = timeToLive;
+        mCacheSoftTtl = softTimeToLive;
+    }
+
+    /**
+     * Reset the cache for this request, to force an update over the network.
+     */
+    public void setShouldForceUpdate() {
+        mResetCache = true;
+    }
+
+    /**
+     * Returns true if this request should ignore the cache and force a fresh update over the network.
+     */
+    public boolean shouldForceUpdate() {
+        return mResetCache;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return mHeaders;
+    }
+
+    public void setHTTPAuthHeaderOnMatchingURL(HTTPAuthManager httpAuthManager) {
+        HTTPAuthModel httpAuthModel = httpAuthManager.getHTTPAuthModel(getUrl());
+        if (httpAuthModel != null) {
+            String creds = String.format("%s:%s", httpAuthModel.getUsername(), httpAuthModel.getPassword());
+            String auth = "Basic " + Base64.encodeToString(creds.getBytes(), Base64.NO_WRAP);
+            mHeaders.put("Authorization", auth);
+        }
+    }
+
+    public void setOnAuthFailedListener(OnAuthFailedListener onAuthFailedListener) {
+        mOnAuthFailedListener = onAuthFailedListener;
+    }
+
+    public void setOnParseErrorListener(OnParseErrorListener onParseErrorListener) {
+        mOnParseErrorListener = onParseErrorListener;
+    }
+
+    public void setUserAgent(String userAgent) {
+        mHeaders.put(USER_AGENT_HEADER, userAgent);
+    }
+
+    public void addHeader(String header, String value) {
+        mHeaders.put(header, value);
+    }
+
+    /**
+     * Convenience method for setting a {@link com.android.volley.RetryPolicy} with no retries.
+     */
+    public void disableRetries() {
+        setRetryPolicy(new DefaultRetryPolicy(DEFAULT_REQUEST_TIMEOUT, 0, DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
+    }
+
+    /**
+     * Generate a cache entry for this request.
+     * <p>
+     * If caching has been enabled through {@link BaseRequest#enableCaching(int, int)}, the expiry parameters that were
+     * given are used to configure the cache entry.
+     * <p>
+     * Otherwise, just generate a cache entry from the response's cache headers (default behaviour).
+     */
+    protected Cache.Entry createCacheEntry(NetworkResponse response) {
+        Cache.Entry cacheEntry = HttpHeaderParser.parseCacheHeaders(response);
+
+        if (!shouldCache()) {
+            return cacheEntry;
+        }
+
+        if (cacheEntry == null) {
+            cacheEntry = new Cache.Entry();
+
+            String headerValue = response.headers.get("Date");
+            if (headerValue != null) {
+                cacheEntry.serverDate = HttpHeaderParser.parseDateAsEpoch(headerValue);
+            }
+
+            headerValue = response.headers.get("Last-Modified");
+            if (headerValue != null) {
+                cacheEntry.lastModified = HttpHeaderParser.parseDateAsEpoch(headerValue);
+            }
+
+            cacheEntry.data = response.data;
+            cacheEntry.responseHeaders = response.headers;
+        }
+
+        long now = System.currentTimeMillis();
+        cacheEntry.ttl = now + mCacheTtl;
+        cacheEntry.softTtl = now + mCacheSoftTtl;
+
+        return cacheEntry;
+    }
+
+    @NonNull
+    private BaseNetworkError getBaseNetworkError(VolleyError volleyError) {
+        // No connection
+        if (volleyError.getCause() instanceof NoConnectionError) {
+            return new BaseNetworkError(GenericErrorType.NO_CONNECTION, volleyError);
+        }
+
+        // Network error
+        if (volleyError.getCause() instanceof NetworkError) {
+            return new BaseNetworkError(GenericErrorType.NETWORK_ERROR, volleyError);
+        }
+
+        // Invalid SSL Handshake
+        if (volleyError.getCause() instanceof SSLHandshakeException) {
+            return new BaseNetworkError(GenericErrorType.INVALID_SSL_CERTIFICATE, volleyError);
+        }
+
+        // Invalid HTTP Auth
+        if (volleyError instanceof AuthFailureError) {
+            return new BaseNetworkError(GenericErrorType.HTTP_AUTH_ERROR, volleyError);
+        }
+
+        // Timeout
+        if (volleyError instanceof TimeoutError) {
+            return new BaseNetworkError(GenericErrorType.TIMEOUT, volleyError);
+        }
+
+        // Parse Error
+        if (volleyError instanceof ParseError) {
+            return new BaseNetworkError(GenericErrorType.PARSE_ERROR, volleyError);
+        }
+
+        // Null networkResponse? Can't get more infos
+        if (volleyError.networkResponse == null) {
+            return new BaseNetworkError(volleyError);
+        }
+
+        // Get Error by HTTP response code
+        String errorMessage = "";
+        if (volleyError.getMessage() != null) {
+            errorMessage = volleyError.getMessage();
+        }
+        switch (volleyError.networkResponse.statusCode) {
+            case 404:
+                return new BaseNetworkError(GenericErrorType.NOT_FOUND, errorMessage, volleyError);
+            case 405:
+                return this instanceof XMLRPCRequest
+                        ? new BaseNetworkError(volleyError, METHOD_NOT_ALLOWED)
+                        : new BaseNetworkError(volleyError);
+            case 451:
+                return new BaseNetworkError(GenericErrorType.CENSORED, errorMessage, volleyError);
+            case 500:
+                return new BaseNetworkError(GenericErrorType.SERVER_ERROR, errorMessage, volleyError);
+            default:
+                break;
+        }
+
+        // Nothing found
+        return new BaseNetworkError(volleyError);
+    }
+
+    public abstract BaseNetworkError deliverBaseNetworkError(@NonNull BaseNetworkError error);
+
+    @Override
+    public final void deliverError(VolleyError volleyError) {
+        Integer statusCode = volleyError.networkResponse != null ? volleyError.networkResponse.statusCode : null;
+        AppLog.e(AppLog.T.API,
+                "Volley error on " + getUrl() + (statusCode != null ? " Status Code: " + statusCode : ""),
+                volleyError);
+        if (volleyError instanceof ParseError && mOnParseErrorListener != null) {
+            OnUnexpectedError error = new OnUnexpectedError(volleyError, "API response parse error");
+            error.addExtra(OnUnexpectedError.KEY_URL, getUrl());
+            mOnParseErrorListener.onParseError(error);
+        }
+        BaseNetworkError baseNetworkError = getBaseNetworkError(volleyError);
+        BaseNetworkError modifiedBaseNetworkError = deliverBaseNetworkError(baseNetworkError);
+        mErrorListener.onErrorResponse(modifiedBaseNetworkError);
+    }
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/network/EncryptedLogUploadRequest.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/network/EncryptedLogUploadRequest.kt
@@ -1,0 +1,57 @@
+package com.automattic.encryptedlogging.network
+
+import com.android.volley.NetworkResponse
+import com.android.volley.ParseError
+import com.android.volley.Request
+import com.android.volley.Response
+import com.android.volley.Response.ErrorListener
+import com.android.volley.VolleyError
+import com.android.volley.toolbox.HttpHeaderParser
+import org.json.JSONObject
+import com.automattic.encryptedlogging.generated.endpoint.WPCOMREST
+
+private const val AUTHORIZATION_HEADER = "Authorization"
+private const val CONTENT_TYPE_HEADER = "Content-Type"
+private const val CONTENT_TYPE_JSON = "application/json"
+private const val UUID_HEADER = "log-uuid"
+
+class EncryptedLogUploadRequest(
+    private val logUuid: String,
+    private val contents: String,
+    private val clientSecret: String,
+    private val successListener: Response.Listener<NetworkResponse>,
+    errorListener: ErrorListener
+) : Request<NetworkResponse>(Method.POST, WPCOMREST.encrypted_logging.urlV1_1, errorListener) {
+    override fun getHeaders(): Map<String, String> {
+        return mapOf(
+                CONTENT_TYPE_HEADER to CONTENT_TYPE_JSON,
+                AUTHORIZATION_HEADER to clientSecret,
+                UUID_HEADER to logUuid
+        )
+    }
+
+    @Suppress("ForbiddenComment")
+    override fun getBody(): ByteArray {
+        // TODO: Max file size is 10MB - maybe we should just handle that in the error callback?
+        return contents.toByteArray()
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    override fun parseNetworkResponse(response: NetworkResponse?): Response<NetworkResponse> {
+        return try {
+            Response.success(response, HttpHeaderParser.parseCacheHeaders(response))
+        } catch (e: Exception) {
+            try {
+                val json = JSONObject(response.toString())
+                val errorMessage = json.getString("message")
+                Response.error(VolleyError(errorMessage))
+            } catch (jsonParsingError: Throwable) {
+                Response.error(ParseError(jsonParsingError))
+            }
+        }
+    }
+
+    override fun deliverResponse(response: NetworkResponse) {
+        successListener.onResponse(response)
+    }
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt
@@ -1,0 +1,82 @@
+package com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog
+
+import com.android.volley.NoConnectionError
+import com.android.volley.RequestQueue
+import com.android.volley.VolleyError
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.json.JSONException
+import org.json.JSONObject
+import com.automattic.encryptedlogging.network.EncryptedLogUploadRequest
+import com.automattic.encryptedlogging.network.rest.wpcom.auth.AppSecrets
+import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploadFailed
+import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploaded
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+private const val INVALID_REQUEST = "invalid-request"
+private const val TOO_MANY_REQUESTS = "too_many_requests"
+
+@Singleton
+class EncryptedLogRestClient @Inject constructor(
+    @Named("regular") private val requestQueue: RequestQueue,
+    private val appSecrets: AppSecrets
+) {
+    suspend fun uploadLog(logUuid: String, contents: String): UploadEncryptedLogResult {
+        return suspendCancellableCoroutine { cont ->
+            val request = EncryptedLogUploadRequest(logUuid, contents, appSecrets.appSecret, {
+                cont.resume(LogUploaded)
+            }, { error ->
+                cont.resume(LogUploadFailed(mapError(error)))
+            })
+            cont.invokeOnCancellation { request.cancel() }
+            requestQueue.add(request)
+        }
+    }
+
+    /**
+     * {
+     *   "error":"too_many_requests",
+     *   "message":"You're sending too many messages. Please slow down."
+     * }
+     * {
+     *   "error":"invalid-request",
+     *   "message":"Invalid UUID: uuids must only contain letters, numbers, dashes, and curly brackets"
+     * }
+     */
+    @Suppress("ReturnCount")
+    private fun mapError(error: VolleyError): UploadEncryptedLogError {
+        if (error is NoConnectionError) {
+            return UploadEncryptedLogError.NoConnection
+        }
+        error.networkResponse?.let { networkResponse ->
+            val statusCode = networkResponse.statusCode
+            val dataString = String(networkResponse.data)
+            val json = try {
+                JSONObject(dataString)
+            } catch (jsonException: JSONException) {
+                AppLog.e(API, "Received response not in JSON format: " + jsonException.message)
+                return UploadEncryptedLogError.Unknown(message = dataString)
+            }
+            val errorMessage = json.getString("message")
+            json.getString("error").let { errorType ->
+                if (errorType == INVALID_REQUEST) {
+                    return UploadEncryptedLogError.InvalidRequest
+                } else if (errorType == TOO_MANY_REQUESTS) {
+                    return UploadEncryptedLogError.TooManyRequests
+                }
+            }
+            return UploadEncryptedLogError.Unknown(statusCode, errorMessage)
+        }
+        return UploadEncryptedLogError.Unknown()
+    }
+}
+
+sealed class UploadEncryptedLogResult {
+    object LogUploaded : UploadEncryptedLogResult()
+    class LogUploadFailed(val error: UploadEncryptedLogError) : UploadEncryptedLogResult()
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/persistence/EncryptedLogSqlUtils.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/persistence/EncryptedLogSqlUtils.kt
@@ -1,0 +1,78 @@
+package com.automattic.encryptedlogging.persistence
+
+import com.wellsql.generated.EncryptedLogModelTable
+import com.yarolegovich.wellsql.SelectQuery
+import com.yarolegovich.wellsql.WellSql
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLog
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogModel
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.FAILED
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.QUEUED
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EncryptedLogSqlUtils @Inject constructor() {
+    fun insertOrUpdateEncryptedLog(encryptedLog: EncryptedLog) {
+        insertOrUpdateEncryptedLogs(listOf(encryptedLog))
+    }
+
+    fun insertOrUpdateEncryptedLogs(encryptedLogs: List<EncryptedLog>) {
+        val encryptedLogModels = encryptedLogs.map { EncryptedLogModel.fromEncryptedLog(it) }
+        // Since we have a unique constraint for uuid with 'on conflict replace', if there is an existing log,
+        // it'll be replaced with the new one. No need to check if the log already exists.
+        WellSql.insert(encryptedLogModels).execute()
+    }
+
+    fun getEncryptedLog(uuid: String): EncryptedLog? {
+        return getEncryptedLogModel(uuid)?.let { EncryptedLog.fromEncryptedLogModel(it) }
+    }
+
+    fun getUploadingEncryptedLogs(): List<EncryptedLog> =
+            getUploadingEncryptedLogsQuery().asModel.map { EncryptedLog.fromEncryptedLogModel(it) }
+
+    fun getNumberOfUploadingEncryptedLogs(): Long = getUploadingEncryptedLogsQuery().count()
+
+    fun deleteEncryptedLogs(encryptedLogList: List<EncryptedLog>) {
+        if (encryptedLogList.isEmpty()) {
+            return
+        }
+        WellSql.delete(EncryptedLogModel::class.java)
+                .where()
+                .isIn(EncryptedLogModelTable.UUID, encryptedLogList.map { it.uuid })
+                .endWhere()
+                .execute()
+    }
+
+    fun getEncryptedLogsForUpload(): List<EncryptedLog> {
+        val uploadStates = listOf(QUEUED, FAILED).map { it.value }
+        return WellSql.select(EncryptedLogModel::class.java)
+                .where()
+                .isIn(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, uploadStates)
+                .endWhere()
+                // Queued status should have priority over failed status
+                .orderBy(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, SelectQuery.ORDER_ASCENDING)
+                // First log that's queued should have priority
+                .orderBy(EncryptedLogModelTable.DATE_CREATED, SelectQuery.ORDER_ASCENDING)
+                .asModel
+                .map {
+                    EncryptedLog.fromEncryptedLogModel(it)
+                }
+    }
+
+    private fun getEncryptedLogModel(uuid: String): EncryptedLogModel? {
+        return WellSql.select(EncryptedLogModel::class.java)
+                .where()
+                .equals(EncryptedLogModelTable.UUID, uuid)
+                .endWhere()
+                .asModel
+                .firstOrNull()
+    }
+
+    private fun getUploadingEncryptedLogsQuery(): SelectQuery<EncryptedLogModel> {
+        return WellSql.select(EncryptedLogModel::class.java)
+            .where()
+            .equals(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, UPLOADING.value)
+            .endWhere()
+    }
+}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -1,0 +1,323 @@
+package com.automattic.encryptedlogging.store
+
+import kotlinx.coroutines.delay
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
+import com.automattic.encryptedlogging.Dispatcher
+import com.automattic.encryptedlogging.Payload
+import com.automattic.encryptedlogging.action.EncryptedLogAction
+import com.automattic.encryptedlogging.action.EncryptedLogAction.RESET_UPLOAD_STATES
+import com.automattic.encryptedlogging.action.EncryptedLogAction.UPLOAD_LOG
+import com.automattic.encryptedlogging.annotations.action.Action
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLog
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.FAILED
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
+import com.automattic.encryptedlogging.model.encryptedlogging.LogEncrypter
+import com.automattic.encryptedlogging.network.BaseRequest.BaseNetworkError
+import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.EncryptedLogRestClient
+import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploadFailed
+import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult.LogUploaded
+import com.automattic.encryptedlogging.persistence.EncryptedLogSqlUtils
+import com.automattic.encryptedlogging.store.EncryptedLogStore.EncryptedLogUploadFailureType.CLIENT_FAILURE
+import com.automattic.encryptedlogging.store.EncryptedLogStore.EncryptedLogUploadFailureType.CONNECTION_FAILURE
+import com.automattic.encryptedlogging.store.EncryptedLogStore.EncryptedLogUploadFailureType.IRRECOVERABLE_FAILURE
+import com.automattic.encryptedlogging.store.EncryptedLogStore.OnEncryptedLogUploaded.EncryptedLogFailedToUpload
+import com.automattic.encryptedlogging.store.EncryptedLogStore.OnEncryptedLogUploaded.EncryptedLogUploadedSuccessfully
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.InvalidRequest
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.MissingFile
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.NoConnection
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.TooManyRequests
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.Unknown
+import com.automattic.encryptedlogging.store.EncryptedLogStore.UploadEncryptedLogError.UnsatisfiedLinkException
+import com.automattic.encryptedlogging.tools.CoroutineEngine
+import com.automattic.encryptedlogging.utils.PreferenceUtils.PreferenceUtilsWrapper
+import org.wordpress.android.util.AppLog
+import org.wordpress.android.util.AppLog.T.API
+import java.io.File
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Depending on the error type, we'll keep a record of the earliest date we can try another encrypted log upload.
+ *
+ * The most important example of this is `TOO_MANY_REQUESTS` error which results in server refusing any uploads for
+ * an hour.
+ */
+private const val ENCRYPTED_LOG_UPLOAD_UNAVAILABLE_UNTIL_DATE = "ENCRYPTED_LOG_UPLOAD_UNAVAILABLE_UNTIL_DATE_PREF_KEY"
+private const val UPLOAD_NEXT_DELAY = 3000L // 3 seconds
+private const val TOO_MANY_REQUESTS_ERROR_DELAY = 60 * 60 * 1000L // 1 hour
+private const val REGULAR_UPLOAD_FAILURE_DELAY = 60 * 1000L // 1 minute
+private const val MAX_RETRY_COUNT = 3
+
+private const val HTTP_STATUS_CODE_500 = 500
+private const val HTTP_STATUS_CODE_599 = 599
+
+@Singleton
+class EncryptedLogStore @Inject constructor(
+    private val encryptedLogRestClient: EncryptedLogRestClient,
+    private val encryptedLogSqlUtils: EncryptedLogSqlUtils,
+    private val coroutineEngine: CoroutineEngine,
+    private val logEncrypter: LogEncrypter,
+    private val preferenceUtils: PreferenceUtilsWrapper,
+    dispatcher: Dispatcher
+) : Store(dispatcher) {
+    override fun onRegister() {
+        AppLog.d(API, this.javaClass.name + ": onRegister")
+    }
+
+    @Subscribe(threadMode = ThreadMode.ASYNC)
+    override fun onAction(action: Action<*>) {
+        val actionType = action.type as? EncryptedLogAction ?: return
+        when (actionType) {
+            UPLOAD_LOG -> {
+                coroutineEngine.launch(API, this, "EncryptedLogStore: On UPLOAD_LOG") {
+                    queueLogForUpload(action.payload as UploadEncryptedLogPayload)
+                }
+            }
+            RESET_UPLOAD_STATES -> {
+                coroutineEngine.launch(API, this, "EncryptedLogStore: On RESET_UPLOAD_STATES") {
+                    resetUploadStates()
+                }
+            }
+        }
+    }
+
+    /**
+     * A method for the client to use to start uploading any encrypted logs that might have been queued.
+     *
+     * This method should be called within a coroutine, possibly in GlobalScope so it's not attached to any one context.
+     */
+    @Suppress("unused")
+    suspend fun uploadQueuedEncryptedLogs() {
+        uploadNext()
+    }
+
+    private suspend fun queueLogForUpload(payload: UploadEncryptedLogPayload) {
+        // If the log file is not valid, there is nothing we can do
+        if (!isValidFile(payload.file)) {
+            emitChange(
+                    EncryptedLogFailedToUpload(
+                            uuid = payload.uuid,
+                            file = payload.file,
+                            error = MissingFile,
+                            willRetry = false
+                    )
+            )
+            return
+        }
+        val encryptedLog = EncryptedLog(
+                uuid = payload.uuid,
+                file = payload.file
+        )
+        encryptedLogSqlUtils.insertOrUpdateEncryptedLog(encryptedLog)
+
+        if (payload.shouldStartUploadImmediately) {
+            uploadNext()
+        }
+    }
+
+    private fun resetUploadStates() {
+        encryptedLogSqlUtils.insertOrUpdateEncryptedLogs(encryptedLogSqlUtils.getUploadingEncryptedLogs().map {
+            it.copy(uploadState = FAILED)
+        })
+    }
+
+    private suspend fun uploadNextWithDelay(delay: Long) {
+        addUploadDelay(delay)
+        // Add a few seconds buffer to avoid possible millisecond comparison issues
+        delay(delay + UPLOAD_NEXT_DELAY)
+        uploadNext()
+    }
+
+    private suspend fun uploadNext() {
+        if (!isUploadAvailable()) {
+            return
+        }
+        // We want to upload a single file at a time
+        encryptedLogSqlUtils.getEncryptedLogsForUpload().firstOrNull()?.let {
+            uploadEncryptedLog(it)
+        }
+    }
+
+    @Suppress("SwallowedException")
+    private suspend fun uploadEncryptedLog(encryptedLog: EncryptedLog) {
+        // If the log file doesn't exist, fail immediately and try the next log file
+        if (!isValidFile(encryptedLog.file)) {
+            handleFailedUpload(encryptedLog, MissingFile)
+            uploadNext()
+            return
+        }
+        try {
+            val encryptedText = logEncrypter.encrypt(text = encryptedLog.file.readText(), uuid = encryptedLog.uuid)
+
+            // Update the upload state of the log
+            encryptedLog.copy(uploadState = UPLOADING).let {
+                encryptedLogSqlUtils.insertOrUpdateEncryptedLog(it)
+            }
+
+            when (val result = encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedText)) {
+                is LogUploaded -> handleSuccessfulUpload(encryptedLog)
+                is LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
+            }
+        } catch (e: UnsatisfiedLinkError) {
+            handleFailedUpload(encryptedLog, UnsatisfiedLinkException)
+        }
+    }
+
+    private suspend fun handleSuccessfulUpload(encryptedLog: EncryptedLog) {
+        deleteEncryptedLog(encryptedLog)
+        emitChange(EncryptedLogUploadedSuccessfully(uuid = encryptedLog.uuid, file = encryptedLog.file))
+        uploadNext()
+    }
+
+    private suspend fun handleFailedUpload(encryptedLog: EncryptedLog, error: UploadEncryptedLogError) {
+        val failureType = mapUploadEncryptedLogError(error)
+
+        val (isFinalFailure, finalFailureCount) = when (failureType) {
+            IRRECOVERABLE_FAILURE -> {
+                Pair(true, encryptedLog.failedCount + 1)
+            }
+            CONNECTION_FAILURE -> {
+                Pair(false, encryptedLog.failedCount)
+            }
+            CLIENT_FAILURE -> {
+                val newFailedCount = encryptedLog.failedCount + 1
+                Pair(newFailedCount >= MAX_RETRY_COUNT, newFailedCount)
+            }
+        }
+
+        if (isFinalFailure) {
+            deleteEncryptedLog(encryptedLog)
+        } else {
+            encryptedLogSqlUtils.insertOrUpdateEncryptedLog(
+                    encryptedLog.copy(
+                            uploadState = FAILED,
+                            failedCount = finalFailureCount
+                    )
+            )
+        }
+
+        emitChange(
+                EncryptedLogFailedToUpload(
+                        uuid = encryptedLog.uuid,
+                        file = encryptedLog.file,
+                        error = error,
+                        willRetry = !isFinalFailure
+                )
+        )
+        // If a log failed to upload for the final time, we don't need to add any delay since the log is the problem.
+        // Otherwise, the only special case that requires an extra long delay is `TOO_MANY_REQUESTS` upload error.
+        if (isFinalFailure) {
+            uploadNext()
+        } else {
+            if (error is TooManyRequests) {
+                uploadNextWithDelay(TOO_MANY_REQUESTS_ERROR_DELAY)
+            } else {
+                uploadNextWithDelay(REGULAR_UPLOAD_FAILURE_DELAY)
+            }
+        }
+    }
+
+    private fun mapUploadEncryptedLogError(error: UploadEncryptedLogError): EncryptedLogUploadFailureType {
+        return when (error) {
+            is NoConnection -> {
+                CONNECTION_FAILURE
+            }
+            is TooManyRequests -> {
+                CONNECTION_FAILURE
+            }
+            is InvalidRequest -> {
+                IRRECOVERABLE_FAILURE
+            }
+            is MissingFile -> {
+                IRRECOVERABLE_FAILURE
+            }
+            is UnsatisfiedLinkException -> {
+                IRRECOVERABLE_FAILURE
+            }
+            is Unknown -> {
+                when {
+                    (HTTP_STATUS_CODE_500..HTTP_STATUS_CODE_599).contains(error.statusCode) -> {
+                        CONNECTION_FAILURE
+                    }
+                    else -> {
+                        CLIENT_FAILURE
+                    }
+                }
+            }
+        }
+    }
+
+    private fun deleteEncryptedLog(encryptedLog: EncryptedLog) {
+        encryptedLogSqlUtils.deleteEncryptedLogs(listOf(encryptedLog))
+    }
+
+    private fun isValidFile(file: File): Boolean = file.exists() && file.canRead()
+
+    /**
+     * Checks if encrypted logs can be uploaded at this time.
+     *
+     * If we are already uploading another encrypted log or if we are manually delaying the uploads due to server errors
+     * encrypted log uploads will not be available.
+     */
+    private fun isUploadAvailable(): Boolean {
+        if (encryptedLogSqlUtils.getNumberOfUploadingEncryptedLogs() > 0) {
+            // We are already uploading another log file
+            return false
+        }
+        preferenceUtils.getFluxCPreferences().getLong(ENCRYPTED_LOG_UPLOAD_UNAVAILABLE_UNTIL_DATE, -1L).let {
+            return it <= Date().time
+        }
+    }
+
+    private fun addUploadDelay(delayDuration: Long) {
+        val date = Date().time + delayDuration
+        preferenceUtils.getFluxCPreferences().edit().putLong(ENCRYPTED_LOG_UPLOAD_UNAVAILABLE_UNTIL_DATE, date).apply()
+    }
+
+    /**
+     * Payload to be used to queue a file to be encrypted and uploaded.
+     *
+     * [shouldStartUploadImmediately] property will be used by [EncryptedLogStore] to decide whether the encryption and
+     * upload should be initiated immediately. Since the main use case to queue a log file to be uploaded is a crash,
+     * the default value is `false`. If we try to upload the log file during a crash, there won't be enough time to
+     * encrypt and upload it, which means it'll just fail. On the other hand, for developer initiated crash monitoring
+     * events, it'd be good, but not essential, to set it to `true` so we can upload it as soon as possible.
+     */
+    class UploadEncryptedLogPayload(
+        val uuid: String,
+        val file: File,
+        val shouldStartUploadImmediately: Boolean = false
+    ) : Payload<BaseNetworkError>()
+
+    sealed class OnEncryptedLogUploaded(val uuid: String, val file: File) : Store.OnChanged<UploadEncryptedLogError>() {
+        class EncryptedLogUploadedSuccessfully(uuid: String, file: File) : OnEncryptedLogUploaded(uuid, file)
+        class EncryptedLogFailedToUpload(
+            uuid: String,
+            file: File,
+            error: UploadEncryptedLogError,
+            val willRetry: Boolean
+        ) : OnEncryptedLogUploaded(uuid, file) {
+            init {
+                this.error = error
+            }
+        }
+    }
+
+    sealed class UploadEncryptedLogError : OnChangedError {
+        class Unknown(val statusCode: Int? = null, val message: String? = null) : UploadEncryptedLogError()
+        object InvalidRequest : UploadEncryptedLogError()
+        object TooManyRequests : UploadEncryptedLogError()
+        object NoConnection : UploadEncryptedLogError()
+        object MissingFile : UploadEncryptedLogError()
+        object UnsatisfiedLinkException : UploadEncryptedLogError()
+    }
+
+    /**
+     * These are internal failure types to make it easier to deal with encrypted log upload errors.
+     */
+    private enum class EncryptedLogUploadFailureType {
+        IRRECOVERABLE_FAILURE, CONNECTION_FAILURE, CLIENT_FAILURE
+    }
+}

--- a/encryptedlogging/src/test/kotlin/com/automattic/encryptedlogging/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/encryptedlogging/src/test/kotlin/com/automattic/encryptedlogging/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -1,0 +1,183 @@
+package com.automattic.encryptedlogging.encryptedlog
+
+import com.yarolegovich.wellsql.WellSql
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import com.automattic.encryptedlogging.SingleStoreWellSqlConfigForTests
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLog
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogModel
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.FAILED
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.QUEUED
+import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.UPLOADING
+import com.automattic.encryptedlogging.persistence.EncryptedLogSqlUtils
+import java.io.File
+import java.time.temporal.ChronoUnit.SECONDS
+import java.util.Date
+import java.util.UUID
+import kotlin.random.Random
+
+private const val TEST_UUID = "TEST_UUID"
+private const val TEST_FILE_PATH = "TEST_FILE_PATH"
+
+@RunWith(RobolectricTestRunner::class)
+class EncryptedLogSqlUtilsTest {
+    private lateinit var sqlUtils: EncryptedLogSqlUtils
+
+    @Before
+    fun setUp() {
+        val appContext = RuntimeEnvironment.application.applicationContext
+        val config = SingleStoreWellSqlConfigForTests(appContext, EncryptedLogModel::class.java)
+        WellSql.init(config)
+        config.reset()
+
+        sqlUtils = EncryptedLogSqlUtils()
+    }
+
+    @Test
+    fun `test insert encrypted log`() {
+        // Assert that there are no encrypted logs with the test uuid
+        assertThat(getTestEncryptedLogFromDB()).isNull()
+
+        // Insert an encrypted log with uuid
+        val logToBeInserted = createTestEncryptedLog()
+        sqlUtils.insertOrUpdateEncryptedLog(logToBeInserted)
+
+        // Assert that the encrypted log from the DB is the same as the one we inserted
+        val log = getTestEncryptedLogFromDB()
+        assertThat(log).isEqualToComparingFieldByField(logToBeInserted)
+    }
+
+    @Test
+    fun `test insert multiple encrypted logs`() {
+        // Assert that there are no encrypted logs with the test uuid
+        assertThat(getTestEncryptedLogFromDB()).isNull()
+
+        // Insert an encrypted log with uuid
+        val uuidList = (1..5).map { "uuid-prefix-$it" }
+        val logsToBeInserted = uuidList.map {
+            createTestEncryptedLog(uuid = it)
+        }
+        sqlUtils.insertOrUpdateEncryptedLogs(logsToBeInserted)
+
+        // Assert that the encrypted logs from the DB is the same as the ones we inserted
+        uuidList.forEachIndexed { index, uuid ->
+            val log = getTestEncryptedLogFromDB(uuid)
+            assertThat(log).isEqualToComparingFieldByField(logsToBeInserted[index])
+        }
+    }
+
+    @Test
+    fun `test update encrypted log`() {
+        // Insert an initial encrypted log
+        val initialLog = createTestEncryptedLog()
+        sqlUtils.insertOrUpdateEncryptedLog(initialLog)
+        assertThat(getTestEncryptedLogFromDB()).isEqualToComparingFieldByField(initialLog)
+
+        // Create a copy of the encrypted log by changing its upload state (which will be the common usage)
+        val newUploadState = EncryptedLogUploadState.UPLOADING
+        val updatedLog = initialLog.copy(uploadState = newUploadState)
+        sqlUtils.insertOrUpdateEncryptedLog(updatedLog)
+
+        // Assert that the encrypted log in the DB is the one with the correct upload state
+        val updatedLogFromDB = getTestEncryptedLogFromDB()
+        assertThat(requireNotNull(updatedLogFromDB?.uploadState)).isEqualTo(newUploadState)
+        // This verifies the expected state as well but separating the initial assertion is valuable to show intent
+        assertThat(updatedLogFromDB).isEqualToComparingFieldByField(updatedLog)
+    }
+
+    @Test
+    fun `test delete encrypted log`() {
+        // Insert an initial encrypted log
+        val initialLog = createTestEncryptedLog()
+        sqlUtils.insertOrUpdateEncryptedLog(initialLog)
+        assertThat(getTestEncryptedLogFromDB()).isEqualToComparingFieldByField(initialLog)
+
+        // Delete the encrypted log
+        sqlUtils.deleteEncryptedLogs(listOf(initialLog))
+
+        // Assert that the encrypted log no longer exists
+        assertThat(getTestEncryptedLogFromDB()).isNull()
+    }
+
+    @Test
+    fun `test get uploading encrypted logs`() {
+        // Insert an encrypted log with uuid
+        val logToBeInserted = createTestEncryptedLog(uploadState = UPLOADING)
+        sqlUtils.insertOrUpdateEncryptedLog(logToBeInserted)
+
+        // Assert that the encrypted log from the DB is the same as the one we inserted
+        val uploadingEncryptedLogs = sqlUtils.getUploadingEncryptedLogs()
+        assertThat(uploadingEncryptedLogs).hasSize(1)
+        assertThat(uploadingEncryptedLogs.first()).isEqualToComparingFieldByField(logToBeInserted)
+    }
+
+    @Test
+    fun `test uploading encrypted logs count for empty DB`() {
+        assertThat(sqlUtils.getNumberOfUploadingEncryptedLogs()).isEqualTo(0)
+    }
+
+    @Test
+    fun `test uploading encrypted logs for random number`() {
+        Random.nextInt(100).let { numberOfLogs ->
+            repeat(numberOfLogs) {
+                sqlUtils.insertOrUpdateEncryptedLog(
+                        createTestEncryptedLog(
+                                uuid = UUID.randomUUID().toString(),
+                                uploadState = UPLOADING
+                        )
+                )
+            }
+            assertThat(sqlUtils.getNumberOfUploadingEncryptedLogs()).isEqualTo(numberOfLogs.toLong())
+        }
+    }
+
+    @Test
+    fun `test get encrypted logs for upload includes QUEUED logs`() {
+        sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = QUEUED))
+
+        assertThat(sqlUtils.getEncryptedLogsForUpload()).isNotEmpty
+    }
+
+    @Test
+    fun `test get encrypted logs for upload includes FAILED logs`() {
+        sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = FAILED))
+
+        assertThat(sqlUtils.getEncryptedLogsForUpload()).isNotEmpty
+    }
+
+    @Test
+    fun `test get encrypted logs for upload does not include UPLOADING logs`() {
+        sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = UPLOADING))
+
+        assertThat(sqlUtils.getEncryptedLogsForUpload()).isEmpty()
+    }
+
+    @Test
+    fun `test get encrypted logs for upload is in correct order`() {
+        sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = FAILED))
+        sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = QUEUED))
+
+        // Queued logs should be uploaded before the failed ones
+        assertThat(sqlUtils.getEncryptedLogsForUpload().firstOrNull()?.uploadState).isEqualTo(QUEUED)
+    }
+
+    private fun getTestEncryptedLogFromDB(uuid: String = TEST_UUID) = sqlUtils.getEncryptedLog(uuid)
+
+    private fun createTestEncryptedLog(
+        uuid: String = TEST_UUID,
+        filePath: String = TEST_FILE_PATH,
+        dateCreated: Date = Date(),
+        uploadState: EncryptedLogUploadState = QUEUED
+    ) = EncryptedLog(
+            uuid = uuid,
+            file = File(filePath),
+            // Bypass the annoying milliseconds comparison issue
+            dateCreated = Date.from(dateCreated.toInstant().truncatedTo(SECONDS)),
+            uploadState = uploadState
+    )
+}


### PR DESCRIPTION
### Description

This PR introduces core code of the Encrypted Logging feature, taken from FluxC project. In consist all commits that modified those files, with changes of packages and imports, to align with the new project structure.

I did it using `filter-repo` tool, with the following command:

```
git filter-repo \
 --path example/src/test/java/org/wordpress/android/fluxc/encryptedlog/EncryptedLogSqlUtilsTest.kt \
 --path-rename example/src/test/java/org/wordpress/android/fluxc/encryptedlog:encryptedlogging/src/test/kotlin/com/automattic/encryptedlogging/encryptedlog \
 --path example/src/androidTest/java/org/wordpress/android/fluxc/release/ReleaseStack_EncryptedLogTest.kt \
 --path-rename example/src/androidTest/java/org/wordpress/android/fluxc/release:encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/release \
 --path example/src/androidTest/java/org/wordpress/android/fluxc/LogEncrypterTest.kt \
 --path-rename example/src/androidTest/java/org/wordpress/android/fluxc/:encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/ \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedLog.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/action/EncryptedLogAction.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/LogEncrypter.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/network/BaseRequest.java \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/network/EncryptedLogUploadRequest.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/encryptedlog/EncryptedLogRestClient.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/persistence/EncryptedLogSqlUtils.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/store/EncryptedLogStore.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptedSecretStreamKey.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/SecretStreamKey.kt \
 --path fluxc/src/main/java/org/wordpress/android/fluxc/model/encryptedlogging/EncryptionUtils.kt \
 --path-rename fluxc/src/main/java/org/wordpress/android/fluxc/:encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/ \
 --tag-rename '':'fluxc-' \
 --replace-text ~/expressions.txt
```

where `expressions.txt` is

```
org.wordpress.android.fluxc==>com.automattic.encryptedlogging
```