### PR TITLE
Fix NPE when mapping from `EncryptedLogModel`

### DIFF
--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptedLog.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/EncryptedLog.kt
@@ -24,7 +24,9 @@ internal data class EncryptedLog(
     companion object {
         fun fromEncryptedLogModel(encryptedLogModel: EncryptedLogModel) =
                 EncryptedLog(
-                        dateCreated = DateTimeUtils.dateUTCFromIso8601(encryptedLogModel.dateCreated),
+                        dateCreated = encryptedLogModel.dateCreated?.let {
+                            DateTimeUtils.dateUTCFromIso8601(it)
+                        } ?: Date(),
                         // Crash if values are missing which shouldn't happen if there are no logic errors
                         uuid = encryptedLogModel.uuid!!,
                         file = File(encryptedLogModel.filePath),


### PR DESCRIPTION
If `EncryptedLogModel#dateCreated` is null, use a newly created `java.util.Date` object

- `EncryptedLog#dateCreated` is not even used anywhere in the app
- I don't see a reason for this value to be `null`, other than a WellSql internal error

Taking both into account, I believe this fix is just fine, even though I can't reproduce the original problem.

Internal issue that this PR is addressing: https://a8c.sentry.io/issues/5501941023/?project=5872941
Also: https://github.com/bloom/DayOne-Android/issues/4423