### PR TITLE
[fix] `getEncryptedLogForUpload` limits to 1 log via SQL

### DIFF
--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/persistence/EncryptedLogSqlUtils.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/persistence/EncryptedLogSqlUtils.kt
@@ -41,7 +41,7 @@ internal class EncryptedLogSqlUtils {
                 .execute()
     }
 
-    fun getEncryptedLogsForUpload(): List<EncryptedLog> {
+    fun getEncryptedLogForUpload(): EncryptedLog? {
         val uploadStates = listOf(QUEUED, FAILED).map { it.value }
         return WellSql.select(EncryptedLogModel::class.java)
                 .where()
@@ -51,10 +51,12 @@ internal class EncryptedLogSqlUtils {
                 .orderBy(EncryptedLogModelTable.UPLOAD_STATE_DB_VALUE, SelectQuery.ORDER_ASCENDING)
                 // First log that's queued should have priority
                 .orderBy(EncryptedLogModelTable.DATE_CREATED, SelectQuery.ORDER_ASCENDING)
+                .limit(1)
                 .asModel
                 .map {
                     EncryptedLog.fromEncryptedLogModel(it)
                 }
+                .firstOrNull()
     }
 
     private fun getEncryptedLogModel(uuid: String): EncryptedLogModel? {

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -140,7 +140,7 @@ internal class EncryptedLogStore constructor(
             return
         }
         // We want to upload a single file at a time
-        encryptedLogSqlUtils.getEncryptedLogsForUpload().firstOrNull()?.let {
+        encryptedLogSqlUtils.getEncryptedLogForUpload()?.let {
             uploadEncryptedLog(it)
         }
     }

--- a/encryptedlogging/src/test/kotlin/com/automattic/encryptedlogging/encryptedlog/EncryptedLogSqlUtilsTest.kt
+++ b/encryptedlogging/src/test/kotlin/com/automattic/encryptedlogging/encryptedlog/EncryptedLogSqlUtilsTest.kt
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLog
-import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogModel
 import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState
 import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.FAILED
 import com.automattic.encryptedlogging.model.encryptedlogging.EncryptedLogUploadState.QUEUED
@@ -139,21 +138,21 @@ class EncryptedLogSqlUtilsTest {
     fun `test get encrypted logs for upload includes QUEUED logs`() {
         sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = QUEUED))
 
-        assertThat(sqlUtils.getEncryptedLogsForUpload()).isNotEmpty
+        assertThat(sqlUtils.getEncryptedLogForUpload()).isNotNull
     }
 
     @Test
     fun `test get encrypted logs for upload includes FAILED logs`() {
         sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = FAILED))
 
-        assertThat(sqlUtils.getEncryptedLogsForUpload()).isNotEmpty
+        assertThat(sqlUtils.getEncryptedLogForUpload()).isNotNull
     }
 
     @Test
     fun `test get encrypted logs for upload does not include UPLOADING logs`() {
         sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = UPLOADING))
 
-        assertThat(sqlUtils.getEncryptedLogsForUpload()).isEmpty()
+        assertThat(sqlUtils.getEncryptedLogForUpload()).isNull()
     }
 
     @Test
@@ -162,7 +161,7 @@ class EncryptedLogSqlUtilsTest {
         sqlUtils.insertOrUpdateEncryptedLog(createTestEncryptedLog(uploadState = QUEUED))
 
         // Queued logs should be uploaded before the failed ones
-        assertThat(sqlUtils.getEncryptedLogsForUpload().firstOrNull()?.uploadState).isEqualTo(QUEUED)
+        assertThat(sqlUtils.getEncryptedLogForUpload()?.uploadState).isEqualTo(QUEUED)
     }
 
     private fun getTestEncryptedLogFromDB(uuid: String = TEST_UUID) = sqlUtils.getEncryptedLog(uuid)


### PR DESCRIPTION
### What?
Use SQL's `LIMIT 1`, instead of querying all logs and then getting only the first one. 

### Why?
This DB-level performance improvement will reduce the size of the cursor and reduce time when it's opened, making the whole setup less prone to concurrency issues.

This change should also help address `SQLiteBlobTooBigExceptions`, mentioned internally here: p1719488653828869-slack-C027TG8D1BL

See more context internally in https://github.com/bloom/DayOne-Android/pull/4500