### PR TITLE
[Dependency Updates] Update `terl-lazysodium-android` to 5.2.0@aar

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ kotlin = "2.1.21"
 kotlinx-coroutines = '1.10.2'
 ksp = "2.1.21-2.0.2"
 robolectric = "4.14.1"
-terl-lazysodium-android = "5.1.0@aar"
+terl-lazysodium-android = "5.2.0@aar"
 turbine = "1.2.1"
 volley = "1.2.1"
 
@@ -36,7 +36,6 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-# TODO: The native library arm64-v8a/libsodium.so (from com.goterl:lazysodium-android:5.1.0) is not 16 KB aligned
 terl-lazysodium-android = { module = "com.goterl:lazysodium-android", version.ref = "terl-lazysodium-android" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 volley = { group = "com.android.volley", name = "volley", version.ref = "volley" }


### PR DESCRIPTION
Closes: AINFRA-505

---

### Description

This PR updates `terl-lazysodium-android` to [5.2.0@aar](https://github.com/terl/lazysodium-android/releases/tag/v5.2.0).

FYI: This update also solves the `is not 16 KB aligned` warning for this specific `terl-lazysodium-android` native library, effectively making this a fully 16 KB compatible library.

---

### Testing Steps

Using the [DOAndroid](https://github.com/bloom/DayOne-Android) or/and [PCAndroid](https://github.com/Automattic/pocket-casts-android) project, update `automattic-encryptedlogging` to `20-ef2bdcf0cca59bf0cc0b15d48866666d6f48b0fa` (version which is based on this PR's [latest](https://github.com/Automattic/EncryptedLogging/pull/20/commits/ef2bdcf0cca59bf0cc0b15d48866666d6f48b0fa) commit) and make sure that encrypted logging continues to work as expected:

1. Using `App Inspection` from AS find the `encrypted-logging.db` and its sole `EncryptedLogModel` table. Notice that the table is empty, there are no log to be sent.
2. Make the app crash. Using [DOAndroid](https://github.com/bloom/DayOne-Android) for example, you could navigate to `Settings` -> `Developer` and then click `Crash The App`.
3. You might now notice a new db entry within `App Inspection` from AS on that `DETACHED` app (or not, it depends). Now, switch to the `ATTACHED` app and notice the db empty. This is because this db entry/log has been already sent to Sentry already, on app start and after the app crashed. To really notice the entry, trying crashing the app again, this time put the device on offline mode first. Doing that you'll be able to see the entry on the db, even when switching to the newly created `ATTACHED` app.
4. Open [Sentry](https://a8c.sentry.io) and navigate to `Issues`. Find the project you're testing for (for example `day-one-android` or/and `pocket-casts-android`) and check the latest `debug` exceptions. Using [DOAndroid](https://github.com/bloom/DayOne-Android) for example, you could search for `Developer caused a crash!` and check the latest crash. Now navigate at the bottom and check the `uuid`. Verify it is the same `UUID` that you saw on that db entry before.
5. Open [Read Encrypted Logs](https://mc.a8c.com/encrypted-logs.php), copy-paste that `UUID` into `Log UUID`, click `View` and make sure you can read the newly uploaded and now decrypted log.

---

Additionally, run this [ReleaseStack_EncryptedLogTest](https://github.com/Automattic/EncryptedLogging/blob/trunk/encryptedlogging/src/androidTest/kotlin/com/automattic/encryptedlogging/release/ReleaseStack_EncryptedLogTest.kt#L43)  instrumented test locally, and make sure that it runs successfully, and as expected. Note that:

1. It is quite hard to work with this test because `TooManyRequests` can be hit quite easily. At which point you need to wait for a few minutes (15' minutes to half an hour) before being able to verify it is working as expected.
2. In order to verify that this test works as expected one would need to use the debugger and navigate through the flow manually. Otherwise the test might success with a false positive, but actually silently failing on (at least) this `TooManyRequests` problem mentioned above.