### PR TITLE
[API] Expose `observeEncryptedLogsUploadResult` Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependency {
 fun provideEncryptedLogging(
     @ApplicationContext context: Context
 ): EncryptedLogging {
-    return AutomatticEncryptedLogging(
+    return EncryptedLogging.getInstance(
         context,
         // Can be found in secrets
         encryptedLoggingKey = BuildConfig.ENCRYPTION_KEY,
@@ -48,9 +48,7 @@ class MyApplication : Application() {
         encryptedLogging.resetUploadStates()
 
         // Launch upload of stored logs in app's coroutine scope
-        applicationScope.launch {
-            encryptedLogging.uploadEncryptedLogs()
-        }
+        encryptedLogging.uploadEncryptedLogs()
     }
 }
 ```

--- a/encryptedlogging/api/encryptedlogging.api
+++ b/encryptedlogging/api/encryptedlogging.api
@@ -1,11 +1,68 @@
 public abstract interface class com/automattic/encryptedlogging/EncryptedLogging {
 	public static final field Companion Lcom/automattic/encryptedlogging/EncryptedLogging$Companion;
 	public abstract fun enqueueSendingEncryptedLogs (Ljava/lang/String;Ljava/io/File;Z)V
+	public abstract fun observeEncryptedLogsUploadResult ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun resetUploadStates ()V
 	public abstract fun uploadEncryptedLogs ()V
 }
 
 public final class com/automattic/encryptedlogging/EncryptedLogging$Companion {
 	public final fun getInstance (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)Lcom/automattic/encryptedlogging/EncryptedLogging;
+}
+
+public class com/automattic/encryptedlogging/store/OnChanged {
+	public fun <init> ()V
+	public final fun getError ()Lcom/automattic/encryptedlogging/store/OnChangedError;
+	public final fun isError ()Z
+	public final fun setError (Lcom/automattic/encryptedlogging/store/OnChangedError;)V
+}
+
+public abstract interface class com/automattic/encryptedlogging/store/OnChangedError {
+}
+
+public abstract class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded : com/automattic/encryptedlogging/store/OnChanged {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getFile ()Ljava/io/File;
+	public final fun getUuid ()Ljava/lang/String;
+}
+
+public final class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded$EncryptedLogFailedToUpload : com/automattic/encryptedlogging/store/OnEncryptedLogUploaded {
+	public fun <init> (Ljava/lang/String;Ljava/io/File;Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError;Z)V
+	public final fun getWillRetry ()Z
+}
+
+public final class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded$EncryptedLogUploadedSuccessfully : com/automattic/encryptedlogging/store/OnEncryptedLogUploaded {
+	public fun <init> (Ljava/lang/String;Ljava/io/File;)V
+}
+
+public abstract class com/automattic/encryptedlogging/store/UploadEncryptedLogError : com/automattic/encryptedlogging/store/OnChangedError {
+}
+
+public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$InvalidRequest : com/automattic/encryptedlogging/store/UploadEncryptedLogError {
+	public static final field INSTANCE Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError$InvalidRequest;
+}
+
+public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$MissingFile : com/automattic/encryptedlogging/store/UploadEncryptedLogError {
+	public static final field INSTANCE Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError$MissingFile;
+}
+
+public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$NoConnection : com/automattic/encryptedlogging/store/UploadEncryptedLogError {
+	public static final field INSTANCE Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError$NoConnection;
+}
+
+public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$TooManyRequests : com/automattic/encryptedlogging/store/UploadEncryptedLogError {
+	public static final field INSTANCE Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError$TooManyRequests;
+}
+
+public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$Unknown : com/automattic/encryptedlogging/store/UploadEncryptedLogError {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStatusCode ()Ljava/lang/Integer;
+}
+
+public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$UnsatisfiedLinkException : com/automattic/encryptedlogging/store/UploadEncryptedLogError {
+	public static final field INSTANCE Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError$UnsatisfiedLinkException;
 }
 

--- a/encryptedlogging/api/encryptedlogging.api
+++ b/encryptedlogging/api/encryptedlogging.api
@@ -10,17 +10,7 @@ public final class com/automattic/encryptedlogging/EncryptedLogging$Companion {
 	public final fun getInstance (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)Lcom/automattic/encryptedlogging/EncryptedLogging;
 }
 
-public class com/automattic/encryptedlogging/store/OnChanged {
-	public fun <init> ()V
-	public final fun getError ()Lcom/automattic/encryptedlogging/store/OnChangedError;
-	public final fun isError ()Z
-	public final fun setError (Lcom/automattic/encryptedlogging/store/OnChangedError;)V
-}
-
-public abstract interface class com/automattic/encryptedlogging/store/OnChangedError {
-}
-
-public abstract class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded : com/automattic/encryptedlogging/store/OnChanged {
+public abstract class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/io/File;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getFile ()Ljava/io/File;
 	public final fun getUuid ()Ljava/lang/String;
@@ -28,6 +18,7 @@ public abstract class com/automattic/encryptedlogging/store/OnEncryptedLogUpload
 
 public final class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded$EncryptedLogFailedToUpload : com/automattic/encryptedlogging/store/OnEncryptedLogUploaded {
 	public fun <init> (Ljava/lang/String;Ljava/io/File;Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError;Z)V
+	public final fun getError ()Lcom/automattic/encryptedlogging/store/UploadEncryptedLogError;
 	public final fun getWillRetry ()Z
 }
 
@@ -35,7 +26,7 @@ public final class com/automattic/encryptedlogging/store/OnEncryptedLogUploaded$
 	public fun <init> (Ljava/lang/String;Ljava/io/File;)V
 }
 
-public abstract class com/automattic/encryptedlogging/store/UploadEncryptedLogError : com/automattic/encryptedlogging/store/OnChangedError {
+public abstract class com/automattic/encryptedlogging/store/UploadEncryptedLogError {
 }
 
 public final class com/automattic/encryptedlogging/store/UploadEncryptedLogError$InvalidRequest : com/automattic/encryptedlogging/store/UploadEncryptedLogError {

--- a/encryptedlogging/api/encryptedlogging.api
+++ b/encryptedlogging/api/encryptedlogging.api
@@ -1,7 +1,7 @@
 public abstract interface class com/automattic/encryptedlogging/EncryptedLogging {
 	public static final field Companion Lcom/automattic/encryptedlogging/EncryptedLogging$Companion;
 	public abstract fun enqueueSendingEncryptedLogs (Ljava/lang/String;Ljava/io/File;Z)V
-	public abstract fun observeEncryptedLogsUploadResult ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun observeEncryptedLogsUploadResult ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun resetUploadStates ()V
 	public abstract fun uploadEncryptedLogs ()V
 }

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/AutomatticEncryptedLogging.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/AutomatticEncryptedLogging.kt
@@ -14,7 +14,7 @@ import com.automattic.encryptedlogging.store.EncryptedLogStore
 import com.automattic.encryptedlogging.store.OnEncryptedLogUploaded
 import com.automattic.encryptedlogging.utils.PreferenceUtils
 import com.goterl.lazysodium.utils.Key
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -81,7 +81,7 @@ internal class AutomatticEncryptedLogging(
         }
     }
 
-    override fun observeEncryptedLogsUploadResult(): StateFlow<OnEncryptedLogUploaded?> {
+    override fun observeEncryptedLogsUploadResult(): Flow<OnEncryptedLogUploaded?> {
         return encryptedLogStore.uploadState
     }
 }

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/AutomatticEncryptedLogging.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/AutomatticEncryptedLogging.kt
@@ -11,8 +11,10 @@ import com.automattic.encryptedlogging.model.encryptedlogging.LogEncrypter
 import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.EncryptedLogRestClient
 import com.automattic.encryptedlogging.persistence.EncryptedLogDatabase
 import com.automattic.encryptedlogging.store.EncryptedLogStore
+import com.automattic.encryptedlogging.store.OnEncryptedLogUploaded
 import com.automattic.encryptedlogging.utils.PreferenceUtils
 import com.goterl.lazysodium.utils.Key
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -77,5 +79,9 @@ internal class AutomatticEncryptedLogging(
         sdkScope.launch {
             encryptedLogStore.resetUploadStates()
         }
+    }
+
+    override fun observeEncryptedLogsUploadResult(): StateFlow<OnEncryptedLogUploaded?> {
+        return encryptedLogStore.uploadState
     }
 }

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/EncryptedLogging.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/EncryptedLogging.kt
@@ -1,6 +1,8 @@
 package com.automattic.encryptedlogging
 
 import android.content.Context
+import com.automattic.encryptedlogging.store.OnEncryptedLogUploaded
+import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
 public interface EncryptedLogging {
@@ -24,6 +26,11 @@ public interface EncryptedLogging {
      * A method for the client to use to reset the upload states. Usually called on app initialization, before [uploadEncryptedLogs]
      */
     public fun resetUploadStates()
+
+    /**
+     * A method for the client to use to observe the upload result of the encrypted logs.
+     */
+    public fun observeEncryptedLogsUploadResult(): StateFlow<OnEncryptedLogUploaded?>
 
     public companion object {
 

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/EncryptedLogging.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/EncryptedLogging.kt
@@ -2,7 +2,7 @@ package com.automattic.encryptedlogging
 
 import android.content.Context
 import com.automattic.encryptedlogging.store.OnEncryptedLogUploaded
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 public interface EncryptedLogging {
@@ -30,7 +30,7 @@ public interface EncryptedLogging {
     /**
      * A method for the client to use to observe the upload result of the encrypted logs.
      */
-    public fun observeEncryptedLogsUploadResult(): StateFlow<OnEncryptedLogUploaded?>
+    public fun observeEncryptedLogsUploadResult(): Flow<OnEncryptedLogUploaded?>
 
     public companion object {
 

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChanged.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChanged.kt
@@ -1,8 +1,0 @@
-package com.automattic.encryptedlogging.store
-
-public open class OnChanged<T : OnChangedError> {
-    public var error: T? = null
-    public fun isError(): Boolean {
-        return error != null
-    }
-}

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChanged.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChanged.kt
@@ -1,8 +1,8 @@
 package com.automattic.encryptedlogging.store
 
-internal open class OnChanged<T : OnChangedError> {
-    var error: T? = null
-    fun isError(): Boolean {
+public open class OnChanged<T : OnChangedError> {
+    public var error: T? = null
+    public fun isError(): Boolean {
         return error != null
     }
 }

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChangedError.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChangedError.kt
@@ -1,3 +1,3 @@
 package com.automattic.encryptedlogging.store
 
-internal interface OnChangedError
+public interface OnChangedError

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChangedError.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnChangedError.kt
@@ -1,3 +1,0 @@
-package com.automattic.encryptedlogging.store
-
-public interface OnChangedError

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnEncryptedLogUploaded.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnEncryptedLogUploaded.kt
@@ -2,16 +2,20 @@ package com.automattic.encryptedlogging.store
 
 import java.io.File
 
-internal sealed class OnEncryptedLogUploaded(
-    val uuid: String,
-    val file: File
+public sealed class OnEncryptedLogUploaded(
+    public val uuid: String,
+    public val file: File
 ) : OnChanged<UploadEncryptedLogError>() {
-    class EncryptedLogUploadedSuccessfully(uuid: String, file: File) : OnEncryptedLogUploaded(uuid, file)
-    class EncryptedLogFailedToUpload(
+    public class EncryptedLogUploadedSuccessfully(
+        uuid: String,
+        file: File
+    ) : OnEncryptedLogUploaded(uuid, file)
+
+    public class EncryptedLogFailedToUpload(
         uuid: String,
         file: File,
         error: UploadEncryptedLogError,
-        internal val willRetry: Boolean
+        public val willRetry: Boolean
     ) : OnEncryptedLogUploaded(uuid, file) {
         init {
             this.error = error

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnEncryptedLogUploaded.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/OnEncryptedLogUploaded.kt
@@ -5,7 +5,7 @@ import java.io.File
 public sealed class OnEncryptedLogUploaded(
     public val uuid: String,
     public val file: File
-) : OnChanged<UploadEncryptedLogError>() {
+) {
     public class EncryptedLogUploadedSuccessfully(
         uuid: String,
         file: File
@@ -14,11 +14,7 @@ public sealed class OnEncryptedLogUploaded(
     public class EncryptedLogFailedToUpload(
         uuid: String,
         file: File,
-        error: UploadEncryptedLogError,
+        public val error: UploadEncryptedLogError,
         public val willRetry: Boolean
-    ) : OnEncryptedLogUploaded(uuid, file) {
-        init {
-            this.error = error
-        }
-    }
+    ) : OnEncryptedLogUploaded(uuid, file)
 }

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/UploadEncryptedLogError.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/UploadEncryptedLogError.kt
@@ -1,14 +1,14 @@
 package com.automattic.encryptedlogging.store
 
-internal sealed class UploadEncryptedLogError : OnChangedError {
-    class Unknown(
-        val statusCode: Int? = null,
-        val message: String? = null
+public sealed class UploadEncryptedLogError : OnChangedError {
+    public class Unknown(
+        public val statusCode: Int? = null,
+        public val message: String? = null
     ) : UploadEncryptedLogError()
 
-    object InvalidRequest : UploadEncryptedLogError()
-    object TooManyRequests : UploadEncryptedLogError()
-    object NoConnection : UploadEncryptedLogError()
-    object MissingFile : UploadEncryptedLogError()
-    object UnsatisfiedLinkException : UploadEncryptedLogError()
+    public object InvalidRequest : UploadEncryptedLogError()
+    public object TooManyRequests : UploadEncryptedLogError()
+    public object NoConnection : UploadEncryptedLogError()
+    public object MissingFile : UploadEncryptedLogError()
+    public object UnsatisfiedLinkException : UploadEncryptedLogError()
 }

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/UploadEncryptedLogError.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/UploadEncryptedLogError.kt
@@ -1,6 +1,6 @@
 package com.automattic.encryptedlogging.store
 
-public sealed class UploadEncryptedLogError : OnChangedError {
+public sealed class UploadEncryptedLogError {
     public class Unknown(
         public val statusCode: Int? = null,
         public val message: String? = null


### PR DESCRIPTION
Closes: [AINFRA-981](https://linear.app/a8c/issue/AINFRA-981/update-encrypted-logging-library-to-expose)
Internal Discussion: p1752847242612859-slack-C04PWEZSYFL
Future Improvement: #25

---

### Description

This PR brings back the `observeEncryptedLogsUploadResult()` function to SDK, making it publicly available again, effectively reverting the change done in this 3c19605c132a5c19b50fc58ca1bb54639a534aa1 commit.

---

### Testing Steps

Using the [DOAndroid](https://github.com/bloom/DayOne-Android) or/and [PCAndroid](https://github.com/Automattic/pocket-casts-android) project, update `automattic-encryptedlogging` to `26-bc0777f7bed8a7cdf9b1e4213e597a9adf7b834b` (version which is based on this PR's [latest](https://github.com/Automattic/EncryptedLogging/pull/26/commits/bc0777f7bed8a7cdf9b1e4213e597a9adf7b834b) commit) and make sure that encrypted logging continues to work as expected:

1. Using `App Inspection` from AS find the `encrypted-logging.db` and its sole `EncryptedLogModel` table. Notice that the table is empty, there are no log to be sent.
2. Make the app crash. Using [DOAndroid](https://github.com/bloom/DayOne-Android) for example, you could navigate to `Settings` -> `Developer` and then click `Crash The App`.
3. You might now notice a new db entry within `App Inspection` from AS on that `DETACHED` app (or not, it depends). Now, switch to the `ATTACHED` app and notice the db empty. This is because this db entry/log has been already sent to Sentry already, on app start and after the app crashed. To really notice the entry, trying crashing the app again, this time put the device on offline mode first. Doing that you'll be able to see the entry on the db, even when switching to the newly created `ATTACHED` app.
4. Open [Sentry](https://a8c.sentry.io) and navigate to `Issues`. Find the project you're testing for (for example `day-one-android` or/and `pocket-casts-android`) and check the latest `debug` exceptions. Using [DOAndroid](https://github.com/bloom/DayOne-Android) for example, you could search for `Developer caused a crash!` and check the latest crash. Now navigate at the bottom and check the `uuid`. Verify it is the same `UUID` that you saw on that db entry before.
5. Open [Read Encrypted Logs](https://mc.a8c.com/encrypted-logs.php), copy-paste that `UUID` into `Log UUID`, click `View` and make sure you can read the newly uploaded and now decrypted log.

---

Additionally, make sure that the added back `observeEncryptedLogsUploadResult()` works as expected. For example, for [DOAndroid](https://github.com/bloom/DayOne-Android), you could make sure that this [encryptedLogging.observeEncryptedLogsUploadResult().collect { ... }](https://github.com/bloom/DayOne-Android/blob/trunk/app/src/main/java/com/dayoneapp/dayone/utils/EncryptedLoggingInitializer.kt#L22-L39) logic still works as expected.