### PR TITLE
[OutOfMemoryError] Fix OOM at `LogEncrypt.encrypt(...)`

### DIFF
--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
@@ -1,12 +1,16 @@
 package com.automattic.encryptedlogging.model.encryptedlogging
 
 import android.util.Base64
+import android.util.Log
 import com.goterl.lazysodium.interfaces.SecretStream
 import com.goterl.lazysodium.interfaces.SecretStream.State
 import com.goterl.lazysodium.utils.Key
+import java.util.Locale
 
 private const val ENCODED_ENCRYPTED_KEY_LENGTH = 108
 private const val ENCODED_HEADER_LENGTH = 32
+// The API accepts logs up to 10MB, but we leave enough headroom for encoding overhead
+private const val MAX_LOG_SIZE = 5 * 1024 * 1024 // 5MB
 
 internal data class EncryptedLoggingKey(val publicKey: Key)
 
@@ -17,27 +21,48 @@ internal data class EncryptedLoggingKey(val publicKey: Key)
  *
  */
 internal class LogEncrypter(private val encryptedLoggingKey: EncryptedLoggingKey) {
+    companion object {
+        private val TAG = LogEncrypter::class.java.simpleName
+    }
+
     /**
      * Encrypts the given [text]. It also adds the given [uuid] to its headers.
      *
      * @param text Text contents to be encrypted
      * @param uuid Uuid for the encrypted log
      */
-    fun encrypt(text: String, uuid: String): String = buildString {
-        val state = State.ByReference()
-        append(buildHeader(uuid, state))
-        val lines = text.lines()
-        lines.asSequence().mapIndexed { index, line ->
-            if (index + 1 >= lines.size) {
-                // If it's the last element
-                line
-            } else {
-                "$line\n"
-            }
-        }.forEach { line ->
-            append(buildMessage(line, state))
+    fun encrypt(text: String, uuid: String): String {
+        val trimmedText = if (text.length > MAX_LOG_SIZE) {
+            Log.w(TAG, "Log with uuid $uuid is too big (${text.length.toMB()}mb), " +
+                    "max allowed log size is ${MAX_LOG_SIZE.toMB()}mb; log got trimmed.")
+            text.takeLast(MAX_LOG_SIZE) // Keep the last N bytes (most recent logs)
+        } else {
+            text
         }
-        append(buildFooter(state))
+        return buildString {
+            val state = State.ByReference()
+            append(buildHeader(uuid, state))
+            val lines = trimmedText.lines()
+            lines.asSequence().mapIndexed { index, line ->
+                if (index + 1 >= lines.size) {
+                    // If it's the last element
+                    line
+                } else {
+                    "$line\n"
+                }
+            }.forEach { line ->
+                append(buildMessage(line, state))
+            }
+            append(buildFooter(state))
+        }
+    }
+
+    private fun Int.toMB(): String {
+        return String.format(
+            Locale.US,
+            "%.2f",
+            this.toFloat() / 1024.0 / 1024.0
+        )
     }
 
     /**

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
@@ -2,13 +2,14 @@ package com.automattic.encryptedlogging.model.encryptedlogging
 
 import android.util.Base64
 import android.util.Log
+import com.automattic.encryptedlogging.utils.Utils.toMB
 import com.goterl.lazysodium.interfaces.SecretStream
 import com.goterl.lazysodium.interfaces.SecretStream.State
 import com.goterl.lazysodium.utils.Key
-import java.util.Locale
 
 private const val ENCODED_ENCRYPTED_KEY_LENGTH = 108
 private const val ENCODED_HEADER_LENGTH = 32
+
 // The API accepts logs up to 10MB, but we leave enough headroom for encoding overhead
 private const val MAX_LOG_SIZE = 5 * 1024 * 1024 // 5MB
 
@@ -55,14 +56,6 @@ internal class LogEncrypter(private val encryptedLoggingKey: EncryptedLoggingKey
             }
             append(buildFooter(state))
         }
-    }
-
-    private fun Int.toMB(): String {
-        return String.format(
-            Locale.US,
-            "%.2f",
-            this.toFloat() / 1024.0 / 1024.0
-        )
     }
 
     /**

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/model/encryptedlogging/LogEncrypter.kt
@@ -1,17 +1,12 @@
 package com.automattic.encryptedlogging.model.encryptedlogging
 
 import android.util.Base64
-import android.util.Log
-import com.automattic.encryptedlogging.utils.Utils.toMB
 import com.goterl.lazysodium.interfaces.SecretStream
 import com.goterl.lazysodium.interfaces.SecretStream.State
 import com.goterl.lazysodium.utils.Key
 
 private const val ENCODED_ENCRYPTED_KEY_LENGTH = 108
 private const val ENCODED_HEADER_LENGTH = 32
-
-// The API accepts logs up to 10MB, but we leave enough headroom for encoding overhead
-private const val MAX_LOG_SIZE = 5 * 1024 * 1024 // 5MB
 
 internal data class EncryptedLoggingKey(val publicKey: Key)
 
@@ -22,40 +17,27 @@ internal data class EncryptedLoggingKey(val publicKey: Key)
  *
  */
 internal class LogEncrypter(private val encryptedLoggingKey: EncryptedLoggingKey) {
-    companion object {
-        private val TAG = LogEncrypter::class.java.simpleName
-    }
-
     /**
      * Encrypts the given [text]. It also adds the given [uuid] to its headers.
      *
      * @param text Text contents to be encrypted
      * @param uuid Uuid for the encrypted log
      */
-    fun encrypt(text: String, uuid: String): String {
-        val trimmedText = if (text.length > MAX_LOG_SIZE) {
-            Log.w(TAG, "Log with uuid $uuid is too big (${text.length.toMB()}mb), " +
-                    "max allowed log size is ${MAX_LOG_SIZE.toMB()}mb; log got trimmed.")
-            text.takeLast(MAX_LOG_SIZE) // Keep the last N bytes (most recent logs)
-        } else {
-            text
-        }
-        return buildString {
-            val state = State.ByReference()
-            append(buildHeader(uuid, state))
-            val lines = trimmedText.lines()
-            lines.asSequence().mapIndexed { index, line ->
-                if (index + 1 >= lines.size) {
-                    // If it's the last element
-                    line
-                } else {
-                    "$line\n"
-                }
-            }.forEach { line ->
-                append(buildMessage(line, state))
+    fun encrypt(text: String, uuid: String): String = buildString {
+        val state = State.ByReference()
+        append(buildHeader(uuid, state))
+        val lines = text.lines()
+        lines.asSequence().mapIndexed { index, line ->
+            if (index + 1 >= lines.size) {
+                // If it's the last element
+                line
+            } else {
+                "$line\n"
             }
-            append(buildFooter(state))
+        }.forEach { line ->
+            append(buildMessage(line, state))
         }
+        append(buildFooter(state))
     }
 
     /**

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -147,6 +147,7 @@ internal class EncryptedLogStore private constructor(
                 uuid = encryptedLog.uuid
             )
         }
+        Log.d(TAG, "The size of encrypted text with uuid ${encryptedLog.uuid} is: ${encryptedText.length.toMB()}mb")
         uploadEncryptedLog(encryptedLog, encryptedText)
     }
 

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -136,19 +136,16 @@ internal class EncryptedLogStore private constructor(
         }
         try {
             val encryptedText = logEncrypter.encrypt(text = encryptedLog.file.readText(), uuid = encryptedLog.uuid)
-            Log.d(TAG, "Successfully encrypted encrypted log with uuid: ${encryptedLog.uuid} " +
-                    "and length: ${encryptedText.length}")
 
             // Update the upload state of the log
             encryptedLog.copy(uploadState = EncryptedLogUploadState.UPLOADING).let {
                 encryptedLogDao.upsertEncryptedLog(EncryptedLogEntity.fromEncryptedLog(it))
             }
 
-            handleSuccessfulUpload(encryptedLog)
-//            when (val result = encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedText)) {
-//                is UploadEncryptedLogResult.LogUploaded -> handleSuccessfulUpload(encryptedLog)
-//                is UploadEncryptedLogResult.LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
-//            }
+            when (val result = encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedText)) {
+                is UploadEncryptedLogResult.LogUploaded -> handleSuccessfulUpload(encryptedLog)
+                is UploadEncryptedLogResult.LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
+            }
         } catch (@Suppress("unused") e: UnsatisfiedLinkError) {
             handleFailedUpload(encryptedLog, UploadEncryptedLogError.UnsatisfiedLinkException)
         }
@@ -161,7 +158,7 @@ internal class EncryptedLogStore private constructor(
             file = encryptedLog.file
         )
         _uploadState.value = uploadState
-        Log.d(TAG, "Successfully encrypted and deleted local log with uuid: ${uploadState.uuid}")
+        Log.d(TAG, "Successfully uploaded encrypted log with uuid: ${uploadState.uuid}")
         uploadNext()
     }
 

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -30,8 +30,8 @@ private const val MAX_RETRY_COUNT = 3
 
 private const val HTTP_STATUS_CODE_500 = 500
 private const val HTTP_STATUS_CODE_599 = 599
-
-private const val MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024 // 10MB
+// The API accepts logs up to 10MB, but we leave enough room for the encryption overhead
+private const val MAX_LOG_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 
 internal class EncryptedLogStore private constructor(
     private val encryptedLogRestClient: EncryptedLogRestClient,
@@ -136,12 +136,12 @@ internal class EncryptedLogStore private constructor(
             uploadNext()
             return
         }
-        val encryptedText = if (encryptedLog.file.length() <= MAX_IN_MEMORY_SIZE) {
+        val encryptedText = if (encryptedLog.file.length() <= MAX_LOG_FILE_SIZE) {
             logEncrypter.encrypt(
                 text = encryptedLog.file.readText(),
                 uuid = encryptedLog.uuid
             )
-        } else { // Large files: extract only the last MAX_IN_MEMORY_SIZE
+        } else { // Large files: extract only the last MAX_LOG_FILE_SIZE
             logEncrypter.encrypt(
                 text = truncateFile(encryptedLog.file, encryptedLog.uuid),
                 uuid = encryptedLog.uuid
@@ -170,8 +170,8 @@ internal class EncryptedLogStore private constructor(
     private fun truncateFile(file: File, uuid: String): String {
         val tempFile = File.createTempFile("truncated_", ".log", file.parentFile)
         try {
-            // Calculate how many bytes to skip from the beginning to keep last MAX_IN_MEMORY_SIZE
-            val skipBytes = file.length() - MAX_IN_MEMORY_SIZE
+            // Calculate how many bytes to skip from the beginning to keep last MAX_LOG_FILE_SIZE
+            val skipBytes = file.length() - MAX_LOG_FILE_SIZE
             file.inputStream().use { input ->
                 input.skip(skipBytes)
                 tempFile.outputStream().use { output ->
@@ -179,7 +179,7 @@ internal class EncryptedLogStore private constructor(
                 }
             }
             Log.w(TAG, "Log file with uuid $uuid is too big (${file.length().toMB()}mb)," +
-                    " max allowed in-memory size is ${MAX_IN_MEMORY_SIZE.toMB()}mb; log file got truncated.")
+                    " max allowed log file size is ${MAX_LOG_FILE_SIZE.toMB()}mb; log file got truncated.")
             return tempFile.readText()
         } finally { // Always clean up the temp file
             tempFile.delete()

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -136,16 +136,19 @@ internal class EncryptedLogStore private constructor(
         }
         try {
             val encryptedText = logEncrypter.encrypt(text = encryptedLog.file.readText(), uuid = encryptedLog.uuid)
+            Log.d(TAG, "Successfully encrypted encrypted log with uuid: ${encryptedLog.uuid} " +
+                    "and length: ${encryptedText.length}")
 
             // Update the upload state of the log
             encryptedLog.copy(uploadState = EncryptedLogUploadState.UPLOADING).let {
                 encryptedLogDao.upsertEncryptedLog(EncryptedLogEntity.fromEncryptedLog(it))
             }
 
-            when (val result = encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedText)) {
-                is UploadEncryptedLogResult.LogUploaded -> handleSuccessfulUpload(encryptedLog)
-                is UploadEncryptedLogResult.LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
-            }
+            handleSuccessfulUpload(encryptedLog)
+//            when (val result = encryptedLogRestClient.uploadLog(encryptedLog.uuid, encryptedText)) {
+//                is UploadEncryptedLogResult.LogUploaded -> handleSuccessfulUpload(encryptedLog)
+//                is UploadEncryptedLogResult.LogUploadFailed -> handleFailedUpload(encryptedLog, result.error)
+//            }
         } catch (@Suppress("unused") e: UnsatisfiedLinkError) {
             handleFailedUpload(encryptedLog, UploadEncryptedLogError.UnsatisfiedLinkException)
         }
@@ -158,7 +161,7 @@ internal class EncryptedLogStore private constructor(
             file = encryptedLog.file
         )
         _uploadState.value = uploadState
-        Log.d(TAG, "Successfully uploaded encrypted log with uuid: ${uploadState.uuid}")
+        Log.d(TAG, "Successfully encrypted and deleted local log with uuid: ${uploadState.uuid}")
         uploadNext()
     }
 

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/store/EncryptedLogStore.kt
@@ -10,6 +10,7 @@ import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.Encrypted
 import com.automattic.encryptedlogging.network.rest.wpcom.encryptedlog.UploadEncryptedLogResult
 import com.automattic.encryptedlogging.persistence.dao.EncryptedLogDao
 import com.automattic.encryptedlogging.utils.PreferenceUtils.PreferenceUtilsWrapper
+import com.automattic.encryptedlogging.utils.Utils.toMB
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.io.File
@@ -29,6 +30,8 @@ private const val MAX_RETRY_COUNT = 3
 
 private const val HTTP_STATUS_CODE_500 = 500
 private const val HTTP_STATUS_CODE_599 = 599
+
+private const val MAX_IN_MEMORY_SIZE = 10 * 1024 * 1024 // 10MB
 
 internal class EncryptedLogStore private constructor(
     private val encryptedLogRestClient: EncryptedLogRestClient,
@@ -126,7 +129,6 @@ internal class EncryptedLogStore private constructor(
         )
     }
 
-    @Suppress("SwallowedException")
     private suspend fun uploadEncryptedLog(encryptedLog: EncryptedLog) {
         // If the log file doesn't exist, fail immediately and try the next log file
         if (!isValidFile(encryptedLog.file)) {
@@ -134,9 +136,23 @@ internal class EncryptedLogStore private constructor(
             uploadNext()
             return
         }
-        try {
-            val encryptedText = logEncrypter.encrypt(text = encryptedLog.file.readText(), uuid = encryptedLog.uuid)
+        val encryptedText = if (encryptedLog.file.length() <= MAX_IN_MEMORY_SIZE) {
+            logEncrypter.encrypt(
+                text = encryptedLog.file.readText(),
+                uuid = encryptedLog.uuid
+            )
+        } else { // Large files: extract only the last MAX_IN_MEMORY_SIZE
+            logEncrypter.encrypt(
+                text = truncateFile(encryptedLog.file, encryptedLog.uuid),
+                uuid = encryptedLog.uuid
+            )
+        }
+        uploadEncryptedLog(encryptedLog, encryptedText)
+    }
 
+    @Suppress("SwallowedException")
+    private suspend fun uploadEncryptedLog(encryptedLog: EncryptedLog, encryptedText: String) {
+        try {
             // Update the upload state of the log
             encryptedLog.copy(uploadState = EncryptedLogUploadState.UPLOADING).let {
                 encryptedLogDao.upsertEncryptedLog(EncryptedLogEntity.fromEncryptedLog(it))
@@ -148,6 +164,25 @@ internal class EncryptedLogStore private constructor(
             }
         } catch (@Suppress("unused") e: UnsatisfiedLinkError) {
             handleFailedUpload(encryptedLog, UploadEncryptedLogError.UnsatisfiedLinkException)
+        }
+    }
+
+    private fun truncateFile(file: File, uuid: String): String {
+        val tempFile = File.createTempFile("truncated_", ".log", file.parentFile)
+        try {
+            // Calculate how many bytes to skip from the beginning to keep last MAX_IN_MEMORY_SIZE
+            val skipBytes = file.length() - MAX_IN_MEMORY_SIZE
+            file.inputStream().use { input ->
+                input.skip(skipBytes)
+                tempFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            Log.w(TAG, "Log file with uuid $uuid is too big (${file.length().toMB()}mb)," +
+                    " max allowed in-memory size is ${MAX_IN_MEMORY_SIZE.toMB()}mb; log file got truncated.")
+            return tempFile.readText()
+        } finally { // Always clean up the temp file
+            tempFile.delete()
         }
     }
 

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/utils/Utils.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/utils/Utils.kt
@@ -3,13 +3,13 @@ package com.automattic.encryptedlogging.utils
 import java.util.Locale
 
 internal object Utils {
-    internal fun Int.toMB() = String.format(
+    fun Int.toMB() = String.format(
         Locale.US,
         "%.2f",
         this.toFloat() / 1024.0 / 1024.0
     )
 
-    internal fun Long.toMB() = String.format(
+    fun Long.toMB() = String.format(
         Locale.US,
         "%.2f",
         this.toFloat() / 1024.0 / 1024.0

--- a/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/utils/Utils.kt
+++ b/encryptedlogging/src/main/kotlin/com/automattic/encryptedlogging/utils/Utils.kt
@@ -1,0 +1,17 @@
+package com.automattic.encryptedlogging.utils
+
+import java.util.Locale
+
+internal object Utils {
+    internal fun Int.toMB() = String.format(
+        Locale.US,
+        "%.2f",
+        this.toFloat() / 1024.0 / 1024.0
+    )
+
+    internal fun Long.toMB() = String.format(
+        Locale.US,
+        "%.2f",
+        this.toFloat() / 1024.0 / 1024.0
+    )
+}


### PR DESCRIPTION
Fixes: #16
Closes: [AINFRA-1217](https://linear.app/a8c/issue/AINFRA-1217)
(Internal) Discussions: p1754667446732699-slack-C030U03RC8Y + p1757585328963649-slack-C030U03RC8Y

---

### Description

This PR resolves a long standing `OutOfMemory` (OOM) error when using this library alongside logs that are of large size.

FYI: Actually, this change resolves a couple more (potential) issues like:
- `ANR`s when the library tries to process large logs (no matter if that results in an OOM or not). See for example: [AINFRA-1182](https://linear.app/a8c/issue/AINFRA-1182)
- `InvalidRequest`s when the library is successful in processing large logs (`10MB+`), but the API respond with `400` just because of the [MAX_FILE_SIZE_IN_BYTES](https://github.a8c.com/Automattic/wpcom/blob/trunk/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-encrypted-logs-endpoint.php#L12C16-L12C38) restriction on [WPCOM_JSON_API_Encrypted_Logs_Endpoint](https://github.a8c.com/Automattic/wpcom/blob/trunk/public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-encrypted-logs-endpoint.php).

Overall, this change:
1. Introduces a `MAX_LOG_FILE_SIZE` of `5MB`, just because the resulting encrypted text is about `1.4` larger per `MB` of a log file, resulting in a final max of about `7MB` that is sent to the API. We could have used `6MB` as the max log file size, which would result in `8.4MB` of encrypted text sent, but it is better to keep enough buffer just in case, and this way, to safeguard ourselves from any `InvalidRequest` responses from the API.
2. Based on this `MAX_LOG_FILE_SIZE` of `5MB`, if a log's file size exceeds this max, it is truncated to that `5MB` of size, skipping the beginning of the log and only keep the more recent logs.

---

### Testing Steps

Using the [DOAndroid](https://github.com/bloom/DayOne-Android) project, update `automattic-encryptedlogging` to `28-f19c0d92473042e5976c92cd7b88cf641456691a` (version which is based on this PR's [latest](https://github.com/Automattic/EncryptedLogging/pull/28/commits/f19c0d92473042e5976c92cd7b88cf641456691a) commit) and make sure that encrypted logging could work with logs of large size.

> [!NOTE]
> I would first advise you to replicate an OOM using your physical/virtual device of choice. To do so, update `automattic-encryptedlogging` to `28-a16584d1c883c758c29e8e40f8bba0c1320ff567` instead. This commit skips the uploading of the encrypted log to the API, and just handles the encryption part.

> [!TIP]
> FYI: You could use the below [DOAndroid](https://github.com/bloom/DayOne-Android) patch, which add the `Fill The Log` development option into the `Developer` screen of the app and on click adds `10000` log lines (or else `4MB` worth of logs). Adding another `0` to that `numberOfLogs` val will give you `40MB` instead, use what you need:
> 
> <details>
>     <summary>patch</summary>
> 
> ```diff
> Subject: [PATCH] Tmp: Assemble release on ci for pr
> ---
> Index: app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperAction.kt
> IDEA additional info:
> Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
> <+>UTF-8
> ===================================================================
> diff --git a/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperAction.kt b/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperAction.kt
> --- a/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperAction.kt	(revision f2622054d961b58bf298d4ab91049be79c19a87b)
> +++ b/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperAction.kt	(date 1757609295757)
> @@ -14,6 +14,8 @@
>  
>      data object CrashApp : DeveloperAction()
>  
> +    data object FillLog : DeveloperAction()
> +
>      data object DeleteAllJournals : DeveloperAction()
>  
>      data object ReloadCurrentMasterKeyStorage : DeveloperAction()
> Index: app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperFragment.kt
> IDEA additional info:
> Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
> <+>UTF-8
> ===================================================================
> diff --git a/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperFragment.kt b/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperFragment.kt
> --- a/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperFragment.kt	(revision f2622054d961b58bf298d4ab91049be79c19a87b)
> +++ b/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperFragment.kt	(date 1757609295757)
> @@ -141,6 +141,20 @@
>                  }
>              }
>              DeveloperAction.CrashApp -> throw Exception("Developer caused a crash!")
> +            DeveloperAction.FillLog -> {
> +                val numberOfLogs = 10000 // 4MB
> +                (0..numberOfLogs).forEachIndexed { index, _ ->
> +                    DOLogger.d(TAG, "Filling log line $index " +
> +                            "[FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST " +
> +                            "FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST " +
> +                            "FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST " +
> +                            "FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST FILL LOG TEST]"
> +                    )
> +                    if (index % (numberOfLogs/5) == 0) {
> +                        Toast.makeText(context, "Filled $index log lines", Toast.LENGTH_SHORT).show()
> +                    }
> +                }
> +            }
>              DeveloperAction.DeleteAllJournals -> deleteAllJournals()
>              DeveloperAction.ReloadCurrentMasterKeyStorage -> viewModel.reloadMasterKeyStorage()
>              DeveloperAction.EnterMasterKey -> enterMasterKey()
> Index: app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperComponentList.kt
> IDEA additional info:
> Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
> <+>UTF-8
> ===================================================================
> diff --git a/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperComponentList.kt b/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperComponentList.kt
> --- a/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperComponentList.kt	(revision f2622054d961b58bf298d4ab91049be79c19a87b)
> +++ b/app/src/main/java/com/dayoneapp/dayone/main/settings/DeveloperComponentList.kt	(date 1757609295757)
> @@ -413,6 +413,10 @@
>          title = { Text(text = stringResource(R.string.crash_app)) },
>          onClick = { onClick(DeveloperAction.CrashApp) },
>      )
> +    SettingItem(
> +        title = { Text(text = stringResource(R.string.fill_log)) },
> +        onClick = { onClick(DeveloperAction.FillLog) },
> +    )
>      if (BuildConfig.DEBUG) {
>          SettingItem(
>              title = { Text(text = stringResource(R.string.purge_welcome_entries)) },
> Index: app/src/main/res/values/strings.xml
> IDEA additional info:
> Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
> <+>UTF-8
> ===================================================================
> diff --git a/app/src/main/res/values/strings.xml b/app/src/main/res/values/strings.xml
> --- a/app/src/main/res/values/strings.xml	(revision f2622054d961b58bf298d4ab91049be79c19a87b)
> +++ b/app/src/main/res/values/strings.xml	(date 1757609295758)
> @@ -881,6 +881,7 @@
>      <string name="reset_passive_message_settings">Reset Passive Messages Settings</string>
>      <string name="reset_today_tooltip_message_settings">Reset Today Tooltip Message Settings</string>
>      <string name="crash_app">Crash The App</string>
> +    <string name="fill_log">Fill The Log</string>
>      <string name="enable_premium_dev">Enable Premium Dev</string>
>      <string name="should_loggedin_premium_dev">You Should be Logged In To Enable Premium Dev</string>
>      <string name="purge_welcome_entries">Purge possible welcome entries</string>
> ```
> 
> </details>
> 
> PS: Don't forget to use the `Device Explorer` to check on the actual size of the log right before you cause a crash (using another `Crash The App` development option from the `Developer` screen of the app. File log path: `/data/data/com.dayoneapp.dayone.debug/files/dayonelogs/com.dayoneapp.dayone.debug YYYY-MM-DD.log`

Follow the below generic steps with a log of `2MB`, `10MB`, `50MB` and `200MB` file size:

1. Using `App Inspection` from AS find the `encrypted-logging.db` and its sole `EncryptedLogModel` table. Notice that the table is empty, there are no log to be sent.
2. Make the app crash. Using [DOAndroid](https://github.com/bloom/DayOne-Android) for example, you could navigate to `Settings` -> `Developer` and then click `Crash The App`.
3. You might now notice a new db entry within `App Inspection` from AS on that `DETACHED` app (or not, it depends). Now, switch to the `ATTACHED` app and notice the db empty. This is because this db entry/log has been already sent to Sentry already, on app start and after the app crashed. To really notice the entry, trying crashing the app again, this time put the device on offline mode first. Doing that you'll be able to see the entry on the db, even when switching to the newly created `ATTACHED` app.
4. Open [Sentry](https://a8c.sentry.io) and navigate to `Issues`. Find the project you're testing for (for example `day-one-android` or/and `pocket-casts-android`) and check the latest `debug` exceptions. Using [DOAndroid](https://github.com/bloom/DayOne-Android) for example, you could search for `Developer caused a crash!` and check the latest crash. Now navigate at the bottom and check the `uuid`. Verify it is the same `UUID` that you saw on that db entry before.
5. Open [Read Encrypted Logs](https://mc.a8c.com/encrypted-logs.php), copy-paste that `UUID` into `Log UUID`, click `View` and make sure you can read the newly uploaded and now decrypted log.

For a log of specific size (see above) expect to get the following results, all without any OOM, or ANR, or an `InvalidRequest` response from the API, and the app should launch instantly, that is, after the crash, without any delay:

1. `2MB`:
    - ℹ️ Enqueueing sending encrypted logs. Log file: com.dayoneapp.dayone.debug YYYY-MM-DD.log, 2.00mb
    - ℹ️ The size of encrypted text with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is: 2.80mb
    - ℹ️ Successfully uploaded encrypted log with uuid: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
2. `10MB`:
    - ℹ️ Enqueueing sending encrypted logs. Log file: com.dayoneapp.dayone.debug YYYY-MM-DD.log, 10.00mb
    - ⚠️ Log file with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is too big (10.00mb), max allowed log file size is 5.00mb; log file got truncated.
    - ℹ️ The size of encrypted text with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is: 7.00mb
    - ℹ️ Successfully uploaded encrypted log with uuid: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
3. `50MB`:
    - ℹ️ Enqueueing sending encrypted logs. Log file: com.dayoneapp.dayone.debug YYYY-MM-DD.log, 50.00mb
    - ⚠️ Log file with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is too big (50.00mb), max allowed log file size is 5.00mb; log file got truncated.
    - ℹ️ The size of encrypted text with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is: 7.00mb
    - ℹ️ Successfully uploaded encrypted log with uuid: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
4. `200MB`:
    - ℹ️ Enqueueing sending encrypted logs. Log file: com.dayoneapp.dayone.debug YYYY-MM-DD.log, 200.00mb
    - ⚠️ Log file with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is too big (200.00mb), max allowed log file size is 5.00mb; log file got truncated.
    - ℹ️ The size of encrypted text with uuid XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX is: 7.00mb
    - ℹ️ Successfully uploaded encrypted log with uuid: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX